### PR TITLE
Refresh feature-separation docs and plan remaining MainWindowViewModel slices

### DIFF
--- a/docs/architecture/clean-feature-separation.md
+++ b/docs/architecture/clean-feature-separation.md
@@ -12,7 +12,9 @@ This document answers the architecture questions raised in [issue #33](https://g
 
 ## Findings
 
-- **Monolithic main view model**: `MainWindowViewModel` (~2,500 lines) owns request editing, response rendering, history, collections, environments, options, scheduling, layout persistence, and logging. All UI actions pass through this single type, so responsibilities are tightly coupled.
+> **Update 2026-06-11:** extraction is well underway. Request execution (HTTP/GraphQL/WebSocket/SSE), response projection, response actions, and the demo-server lifecycle now live in feature-scoped Workflow/Coordinator classes; collections and layout are partially extracted. `MainWindowViewModel` is ~3,430 lines and still owns options apply/import/export, collections UI workflows (forms, inherited-headers autosave), named-layout management, request tabs, history, and scheduled-job commands. Current status and the ordered forward plan live in [`mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md). The findings below describe the original state and are kept for context.
+
+- **Monolithic main view model**: `MainWindowViewModel` (~2,500 lines at the time of writing) owns request editing, response rendering, history, collections, environments, options, scheduling, layout persistence, and logging. All UI actions pass through this single type, so responsibilities are tightly coupled.
 - **Child view models are thin proxies**: dockable VMs such as `RequestViewModel`, `ResponseViewModel`, `LeftPanelViewModel`, and `OptionsViewModel` simply forward to `MainWindowViewModel`. Reusing them elsewhere still drags the entire main VM with it.
 - **Composition is hard-wired**: `App.axaml.cs` creates concrete services and VMs directly, and `DockFactory` constructs all dockables with a `MainWindowViewModel` dependency. Adding any new dock panel requires edits in both `DockFactory` and `MainWindowViewModel`, which blocks feature isolation.
 - **Limited reuse boundaries**: UI pieces share `MainWindowViewModel` state instead of feature-specific contracts. Reusing the request panel or environment editor in another host window would require carrying the whole main VM.
@@ -69,6 +71,7 @@ HttpRequest/     — IRequestHistoryRepository, RequestHistoryEntry, ResolvedHtt
                    HttpRequestDiagnostics, RequestHeader, RequestType, HttpRequestService, CurlFormatter
 OpenApiImport/   — OpenApiImportService
 ScheduledJobs/   — IScheduledJobRepository, ScheduledJobConfig
+Scripting/       — IScriptRunner, ScriptContext, ScriptResponse, ScriptResult
 Sse/             — SseService, SseEvent
 Variables/       — VariableResolver
 WebSocket/       — WebSocketService, WebSocketMessage
@@ -80,30 +83,43 @@ WebSocket/       — WebSocketService, WebSocketMessage
 Demo/                     — DemoServer
 Features/
   About/                  — AboutWindowViewModel, AboutWindow
-  Collections/            — CollectionGroupViewModel, CollectionItemViewModel, LeftPanelViewModel,
+  Collections/            — CollectionsWorkflow, CollectionsManagementCoordinator, CollectionUrlHelper,
+                            CollectionGroupViewModel, CollectionItemViewModel, LeftPanelViewModel,
                             LeftPanelView, BoolToExpandIconConverter
   Cookies/                — CookieJarViewModel, CookieEntryViewModel, CookieJarView
+  Demo/                   — DemoDataWorkflow, DemoServerLifecycleCoordinator
+  Diagnostics/            — DiagnosticsViewModel, DiagnosticsOptions, DiagnosticsWindow,
+                            UnhandledExceptionCollector, UnhandledExceptionEntry
   Environments/           — EnvironmentsViewModel, EnvironmentVariableViewModel, EnvironmentsView
-  GraphQl/                — GraphQlViewModel
-  HttpRequest/            — RequestEditorViewModel, RequestViewModel, ResponseViewModel,
+  GraphQl/                — GraphQlViewModel, GraphQlRequestWorkflow, ManualGraphQlRequestCoordinator
+  HttpRequest/            — RequestEditorViewModel, RequestViewModel, RequestTabViewModel, ResponseViewModel,
+                            HttpRequestWorkflow, ManualHttpRequestCoordinator, HttpResponseProjectionWorkflow,
                             ResponseActionsViewModel, IResponseActionsContext,
                             RequestHeaderViewModel, RequestQueryParameterViewModel,
-                            RequestView, ResponseView, MethodToColorConverter, StatusCodeToColorConverter
-  Layout/                 — DockFactory, DockLayoutSnapshot, FloatingWindowSnapshot, LayoutManagementViewModel,
+                            RequestView, ResponseView, EmbeddedResponseView,
+                            MethodToColorConverter, StatusCodeToColorConverter
+  Layout/                 — DockFactory, DockLayoutSnapshot, DockTreeNode, FloatingWindowSnapshot,
+                            LayoutWorkflow, LayoutTreeWorkflow, LayoutManagementViewModel,
                             LayoutManagementView, LayoutOptions, NamedDockLayout,
                             DraftPersistenceService, DraftHeaderDto, RequestEditorSnapshot
   Logging/                — InMemorySink, LogEntry, LogTab, LogPanelViewModel,
                             LogWindowViewModel, LogPanelView, LogWindow
-  Main/                   — MainWindowViewModel, MainWindow
+  Main/                   — MainWindowViewModel, MainWindow, ResponseSaveFileNamePatternFormatter
   Options/                — ApplicationOptions, AppearanceOptions, HttpOptions, ApplicationOptionsStore,
-                            OptionsViewModel, OptionsView, OptionsWindow
+                            OptionsViewModel, OptionsView, per-page option views (HttpOptionsPageView,
+                            LookAndFeelOptionsPageView, DiagnosticsOptionsPageView, ManageOptionsPageView,
+                            ScheduledJobsOptionsPageView)
   ScheduledJobs/          — ScheduledJobService, ScheduledJobViewModel, ScheduledJobsOptions
+  Scripting/              — RoslynScriptRunner, ScriptViewModel
   Sse/                    — SseViewModel
+  Streaming/              — StreamingConnectionWorkflow
   Variables/              — VariableAutoCompleteController, VariableCompletionData, VariableCompletionEngine,
                             VariableNameHelper, VariableTextBox, VariableTokenColorizer
   WebSocket/              — WebSocketViewModel
   WebView/                — WebViewWindow
-Shared/                   — ReactiveViewModelBase, ReactiveToolBase, NotNullConverter, StringEqualityConverter, TabFontWeightConverter
+Localization/             — Strings.resx, Strings.Designer.cs
+Shared/                   — ReactiveViewModelBase, ReactiveToolBase, DisposableExtensions, HttpContentTypeHelper,
+                            TextHelpers, NotNullConverter, StringEqualityConverter, TabFontWeightConverter
 ```
 
 ## Additional questions to track continuously
@@ -117,9 +133,9 @@ Shared/                   — ReactiveViewModelBase, ReactiveToolBase, NotNullCo
 
 ## Ordered next steps
 
-0. Use the execution plan in [`docs/architecture/mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md) for incremental extraction work and communication-pattern decisions.
+0. Use the execution plan in [`docs/architecture/mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md) for incremental extraction work and communication-pattern decisions — see its "Remaining slices — ordered plan" section for the current slice order (next up: Options workflow).
 1. ~~Feature-centric folder structure~~ ✅ Complete — all projects now use vertical-slice feature folders.
-2. Refactor `DockFactory` to consume feature registrations and stop requiring a `MainWindowViewModel` reference.
-3. Evaluate whether a mediator/event-bus is needed after 1–2 successful slice extractions.
+2. Refactor `DockFactory` to consume feature registrations and stop requiring a `MainWindowViewModel` reference. **Decision 2026-06-11: deliberately deferred until after the remaining `MainWindowViewModel` slices are extracted**, so registrations can target clean feature VMs.
+3. ~~Evaluate whether a mediator/event-bus is needed after 1–2 successful slice extractions.~~ ✅ Resolved — several extractions later, direct Workflow/Coordinator calls plus `IObservable<T>` endpoints cover all communication needs; mediator/event-bus rejected (see the split plan's "Current guidance" section).
 4. Introduce a DI container (e.g., `Microsoft.Extensions.DependencyInjection`) only when constructor/composition friction remains significant after slice extraction.
-5. Consider RX.NET (`System.Reactive`) as an additive communication channel (Option E) for cross-feature notifications, scheduler-controlled async, and collection transforms — see [`docs/architecture/rx-reactive-evaluation.md`](rx-reactive-evaluation.md) for a full trade-off analysis.
+5. ~~Consider RX.NET (`System.Reactive`) as an additive communication channel (Option E)~~ ✅ Superseded — the solution completed a full ReactiveUI/Rx.NET migration (PRs #218–#220); see [`reactiveui-migration-progress.md`](reactiveui-migration-progress.md). [`rx-reactive-evaluation.md`](rx-reactive-evaluation.md) is kept for historical context.

--- a/docs/architecture/clean-feature-separation.md
+++ b/docs/architecture/clean-feature-separation.md
@@ -12,7 +12,7 @@ This document answers the architecture questions raised in [issue #33](https://g
 
 ## Findings
 
-> **Update 2026-06-11:** extraction is well underway. Request execution (HTTP/GraphQL/WebSocket/SSE), response projection, response actions, and the demo-server lifecycle now live in feature-scoped Workflow/Coordinator classes; collections and layout are partially extracted. `MainWindowViewModel` is ~3,430 lines and still owns options apply/import/export, collections UI workflows (forms, inherited-headers autosave), named-layout management, request tabs, history, and scheduled-job commands. Current status and the ordered forward plan live in [`mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md). The findings below describe the original state and are kept for context.
+> **Update 2026-06-11:** extraction is well underway. Request execution (HTTP/GraphQL/WebSocket/SSE), response projection, response actions, the demo-server lifecycle, and options persistence (auto-save/save/export/import via `ApplicationOptionsWorkflow`) now live in feature-scoped Workflow/Coordinator classes; collections and layout are partially extracted. `MainWindowViewModel` still owns the per-option UI projections, collections UI workflows (forms, inherited-headers autosave), named-layout management, request tabs, history, and scheduled-job commands. Current status and the ordered forward plan live in [`mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md). The findings below describe the original state and are kept for context.
 
 - **Monolithic main view model**: `MainWindowViewModel` (~2,500 lines at the time of writing) owns request editing, response rendering, history, collections, environments, options, scheduling, layout persistence, and logging. All UI actions pass through this single type, so responsibilities are tightly coupled.
 - **Child view models are thin proxies**: dockable VMs such as `RequestViewModel`, `ResponseViewModel`, `LeftPanelViewModel`, and `OptionsViewModel` simply forward to `MainWindowViewModel`. Reusing them elsewhere still drags the entire main VM with it.
@@ -106,6 +106,7 @@ Features/
                             LogWindowViewModel, LogPanelView, LogWindow
   Main/                   — MainWindowViewModel, MainWindow, ResponseSaveFileNamePatternFormatter
   Options/                — ApplicationOptions, AppearanceOptions, HttpOptions, ApplicationOptionsStore,
+                            ApplicationOptionsWorkflow, ApplicationOptionsSnapshot, OptionsPersistenceOutcome,
                             OptionsViewModel, OptionsView, per-page option views (HttpOptionsPageView,
                             LookAndFeelOptionsPageView, DiagnosticsOptionsPageView, ManageOptionsPageView,
                             ScheduledJobsOptionsPageView)

--- a/docs/architecture/mainwindowviewmodel-split-plan.md
+++ b/docs/architecture/mainwindowviewmodel-split-plan.md
@@ -2,9 +2,21 @@
 
 ## Context
 
-`MainWindowViewModel` currently contains multiple feature areas and coordination responsibilities in one class (about 4,000 lines). This slows down feature work, increases regression risk, and makes focused testing harder.
+`MainWindowViewModel` contains multiple feature areas and coordination responsibilities in one class (about 4,000 lines when this plan was written; about 3,430 lines as of 2026-06-11). This slows down feature work, increases regression risk, and makes focused testing harder.
 
 This document is a persisted implementation plan for splitting feature logic from `MainWindowViewModel` while keeping behavior stable.
+
+> **Status update (2026-06-11):** Several slices have been extracted since this plan was written, and the solution has since completed a full ReactiveUI/Rx.NET migration (see [`reactiveui-migration-progress.md`](reactiveui-migration-progress.md)), which changes the communication-pattern recommendation below. Current status per slice is tracked in [Extraction status](#extraction-status-2026-06-11) and the forward plan in [Remaining slices — ordered plan](#remaining-slices--ordered-plan-2026-06-11).
+
+## Established extraction convention (Workflow / Coordinator)
+
+The extractions completed so far converged on a two-layer convention. Follow it for the remaining slices:
+
+- **`*Workflow`** — a plain `sealed` class with constructor-injected dependencies that owns one feature pipeline (e.g. `HttpRequestWorkflow`, `CollectionsWorkflow`, `LayoutTreeWorkflow`). It holds no UI state and returns immutable result records (e.g. `HttpRequestExecutionResult`) instead of mutating the caller.
+- **`*Coordinator`** — a `sealed` class that orchestrates a workflow plus its side effects (persistence, reload callbacks, logging) and returns an outcome record (e.g. `ManualHttpRequestCoordinator` → `ManualHttpRequestOutcome`). Exception handling and cancellation semantics live here.
+- **`MainWindowViewModel`** — keeps the `[Reactive]` UI state and `[ReactiveCommand]` entry points, calls the coordinator, and projects the outcome record onto UI properties (e.g. via `HttpResponseProjectionWorkflow`).
+
+Both layers are headless-testable without the Avalonia runtime, which is the main reason for the split.
 
 ## Goals
 
@@ -79,11 +91,41 @@ Each extracted unit should own:
 Recommended extraction order (lowest coupling first):
 
 1. ✅ Response actions (copy/save/open external) — see below
-2. Demo server lifecycle
-3. Collections workflows
-4. Scheduled jobs workflows
-5. Request execution orchestration
-6. Draft/options autosave orchestration
+2. ✅ Demo server lifecycle — `DemoDataWorkflow` + `DemoServerLifecycleCoordinator` (`Features/Demo/`)
+3. 🔶 Collections workflows — `CollectionsWorkflow` + `CollectionsManagementCoordinator` exist (`Features/Collections/`), but the new/rename forms, inherited-headers sync/autosave, filter/sort/display-mode, and import/delete flows still live in `MainWindowViewModel`
+4. Scheduled jobs workflows — `ScheduledJobService` exists, but add/remove commands and persistence hooks are still in `MainWindowViewModel`
+5. ✅ Request execution orchestration — `HttpRequestWorkflow` + `ManualHttpRequestCoordinator` + `HttpResponseProjectionWorkflow` (`Features/HttpRequest/`), `GraphQlRequestWorkflow` + `ManualGraphQlRequestCoordinator` (`Features/GraphQl/`), `StreamingConnectionWorkflow` (`Features/Streaming/`)
+6. Draft/options autosave orchestration — options `Apply*`/save/import/export and the autosave subjects are still in `MainWindowViewModel`; layout has partial extraction via `LayoutWorkflow` + `LayoutTreeWorkflow` (`Features/Layout/`)
+
+<a id="extraction-status-2026-06-11"></a>
+#### Extraction status (2026-06-11)
+
+| Slice | Extracted classes | Status |
+|---|---|---|
+| Response actions | `ResponseActionsViewModel` | ✅ Done |
+| Request execution (HTTP) | `HttpRequestWorkflow`, `ManualHttpRequestCoordinator`, `HttpRequestExecutionResult`, `ManualHttpRequestOutcome` | ✅ Done |
+| Response projection | `HttpResponseProjectionWorkflow` | ✅ Done |
+| GraphQL execution | `GraphQlRequestWorkflow`, `ManualGraphQlRequestCoordinator` | ✅ Done |
+| WebSocket/SSE connection | `StreamingConnectionWorkflow` | ✅ Done |
+| Demo server lifecycle | `DemoDataWorkflow`, `DemoServerLifecycleCoordinator` | ✅ Done |
+| Collections persistence | `CollectionsWorkflow`, `CollectionsManagementCoordinator` | 🔶 Partial — UI workflows still in Main (see slice plan below) |
+| Layout tree/restore | `LayoutWorkflow`, `LayoutTreeWorkflow` | 🔶 Partial — named layouts, geometry, and persistence still in Main |
+| Options apply/import/export | — | ❌ Not started |
+| Scheduled jobs add/remove | — | ❌ Not started |
+| Request tabs + history | — | ❌ Not started |
+
+<a id="remaining-slices--ordered-plan-2026-06-11"></a>
+#### Remaining slices — ordered plan (2026-06-11)
+
+Execute one slice per PR, in this order (lowest coupling first), following the Workflow/Coordinator convention above:
+
+1. **Options workflow** *(next)* — extract the ~15 `Apply*` option methods, `ApplyOptions`, `SaveOptions`, `ExportOptionsAsync`, `ImportOptionsAsync`, and the options autosave subject into an `ApplicationOptionsWorkflow` (+ coordinator if side effects warrant it) under `Features/Options/`. Self-contained, no dock or collection coupling, easiest to test headlessly.
+2. **Collections UI workflows** — finish slice 3: move new/rename collection forms, inherited-headers sync + debounced autosave (~500 lines), filter/sort/display-mode, and import/delete into `CollectionsManagementCoordinator` or a new `CollectionsPanelViewModel`. Consider DynamicData for filter/sort here (see `docs/suggestions/DynamicDataCollections.md`).
+3. **Scheduled jobs workflow** — move `AddScheduledJob`/`RemoveScheduledJobAsync` and persistence hooks into a `ScheduledJobsWorkflow` next to `ScheduledJobService`.
+4. **Request tabs + history** — extract tab lifecycle (`NewRequestTab`, `CloseRequestTab`, `ApplyActiveRequestTab`, `SaveResponseStateForTab`) and history load/filter (`LoadHistoryAsync`, `ApplyHistoryFilter`, `LoadHistoryRequest`) into feature-scoped classes.
+5. **Layout management** — finish the layout slice: named layout save/restore/remove, window geometry, `PersistCurrentLayout`/`ApplyLayoutSnapshot`/`ReapplyStartupLayout` on top of the existing `LayoutWorkflow`/`LayoutTreeWorkflow`. Largest and riskiest; do it once the rest of Main is thin.
+6. **Phase 3 delegation cleanup** — remove `IResponseActionsContext` pass-throughs and other temporary delegation from Main once XAML binds to feature VMs directly.
+7. **DockFactory feature registrations** — only after the slices above: replace the `MainWindowViewModel` constructor dependency in `DockFactory` with per-feature dockable registrations (step 2 in `clean-feature-separation.md`). Deliberately deferred so registrations can point at clean feature VMs.
 
 #### Phase 2 Slice 1 — Response actions ✅ Implemented
 
@@ -146,6 +188,8 @@ Split `RequestEditorViewModelTests` by behavior area, for example:
 
 ## Communication pattern options between modules
 
+> **Superseded note (2026-06-11):** the table below predates the full ReactiveUI/Rx.NET migration (completed in PRs #218–#220). The original recommendation assumed CommunityToolkit.Mvvm as the baseline; that constraint no longer exists. The table is kept for historical context — current guidance follows in the next section.
+
 | Option | Description | Pros | Cons | Impact | Recommendation |
 |---|---|---|---|---|---|
 | A. Direct interface calls (default) | Feature VM/coordinator calls another via small interface contracts | Simple, explicit, easy to debug, minimal infrastructure | Can grow coupling if interfaces become broad | Low migration cost, low risk | **Start here** |
@@ -154,12 +198,16 @@ Split `RequestEditorViewModelTests` by behavior area, for example:
 | D. Mediator/command bus | Commands routed through mediator handlers | Strong separation, extensible for plugins/modules | Indirection, can hide ownership, overkill early | Medium-high cost | Re-evaluate after 1–2 successful extractions |
 | E. RX.NET observable streams | Feature VMs expose `IObservable<T>` endpoints; consumers subscribe with composable operators | Composable fan-out (throttle, filter, combine), `IScheduler` enables time-travel unit tests, pairs with DynamicData for collection transforms | Medium-high learning curve, subscription lifetime management, debugging stream chains | Low if additive alongside CommunityToolkit.Mvvm; high if replacing it | Use selectively for time-dependent features and cross-feature notifications once ≥ 2 features are extracted; see [`docs/architecture/rx-reactive-evaluation.md`](rx-reactive-evaluation.md) |
 
-### Practical recommendation
+### Current guidance (post-ReactiveUI migration, 2026-06-11)
 
-- Use **Option A** as baseline for first extractions.
-- Introduce **Option B** only for true fan-out notifications with no composition needs.
-- Introduce **Option E** where throttling, scheduling, or combining multiple streams adds clear value over raw C# events.
-- Reassess mediator/event-bus only if direct contracts start causing clear composition friction.
+ReactiveUI + Rx.NET is now the solution-wide MVVM stack, so the A-vs-E trade-off has collapsed: both are idiomatic and already in use. Pick per interaction shape:
+
+- **Command-style flows (request/response with a result)** — keep **Option A as direct Workflow/Coordinator calls returning immutable outcome records** (the established convention above). This is explicit, debuggable, and already proven by `ManualHttpRequestCoordinator`/`ManualHttpRequestOutcome`. Do not convert these to streams; a `Task<TOutcome>` is the right shape for one-shot operations.
+- **Notifications and derived state (fan-out, no reply expected)** — use **Option E**: the producing workflow/VM exposes an `IObservable<T>` (Subject-backed or `WhenAnyValue`-derived); consumers subscribe at the composition root with `.DisposeWith(Disposables)`. Already in use for the options-autosave, history-filter, and collection-search subjects in `MainWindowViewModel`; when extracting those slices, move the subject into the owning workflow and expose it as `IObservable<T>`.
+- **Time-dependent behavior (debounce/throttle/timers)** — model as Rx pipelines with an injectable `IScheduler` so tests can use `TestScheduler` (`Microsoft.Reactive.Testing` is already pinned; see `docs/suggestions/SchedulerInjection.md`).
+- **Dialogs and file pickers** — prefer ReactiveUI `Interaction<TInput, TOutput>` over the current `Action` delegates (`OpenAboutWindowAction` etc.) as slices are extracted; this is the planned follow-up from the migration (plan §3.3/§3.5).
+- **Collection filtering/sorting** — use DynamicData (`SourceList` + `Filter`/`Sort`/`Bind`) when extracting the collections and history slices (see `docs/suggestions/DynamicDataCollections.md`).
+- **Rejected: Option B (event aggregator) and `ReactiveUI.MessageBus`** — ReactiveUI's own documentation discourages MessageBus as a service-locator-style pattern that hides flows; explicit `IObservable<T>` endpoints on constructor-injected dependencies provide the same decoupling with visible ownership. **Option D (mediator)** stays rejected — the Workflow/Coordinator extractions have not produced composition friction that would justify it. **Option C (state store)** remains unnecessary.
 
 ## Risk controls
 

--- a/docs/architecture/mainwindowviewmodel-split-plan.md
+++ b/docs/architecture/mainwindowviewmodel-split-plan.md
@@ -110,7 +110,7 @@ Recommended extraction order (lowest coupling first):
 | Demo server lifecycle | `DemoDataWorkflow`, `DemoServerLifecycleCoordinator` | ✅ Done |
 | Collections persistence | `CollectionsWorkflow`, `CollectionsManagementCoordinator` | 🔶 Partial — UI workflows still in Main (see slice plan below) |
 | Layout tree/restore | `LayoutWorkflow`, `LayoutTreeWorkflow` | 🔶 Partial — named layouts, geometry, and persistence still in Main |
-| Options apply/import/export | — | ❌ Not started |
+| Options persistence | `ApplicationOptionsWorkflow`, `ApplicationOptionsSnapshot`, `OptionsPersistenceOutcome` | ✅ Done — auto-save debounce, build/validate, save/export/import; the per-option `Apply*` UI projections stay in Main by design (they mutate Avalonia/app state) |
 | Scheduled jobs add/remove | — | ❌ Not started |
 | Request tabs + history | — | ❌ Not started |
 
@@ -119,8 +119,8 @@ Recommended extraction order (lowest coupling first):
 
 Execute one slice per PR, in this order (lowest coupling first), following the Workflow/Coordinator convention above:
 
-1. **Options workflow** *(next)* — extract the ~15 `Apply*` option methods, `ApplyOptions`, `SaveOptions`, `ExportOptionsAsync`, `ImportOptionsAsync`, and the options autosave subject into an `ApplicationOptionsWorkflow` (+ coordinator if side effects warrant it) under `Features/Options/`. Self-contained, no dock or collection coupling, easiest to test headlessly.
-2. **Collections UI workflows** — finish slice 3: move new/rename collection forms, inherited-headers sync + debounced autosave (~500 lines), filter/sort/display-mode, and import/delete into `CollectionsManagementCoordinator` or a new `CollectionsPanelViewModel`. Consider DynamicData for filter/sort here (see `docs/suggestions/DynamicDataCollections.md`).
+1. ~~**Options workflow**~~ ✅ Done — `ApplicationOptionsWorkflow` (`Features/Options/`) owns the debounced auto-save pipeline (injectable `IScheduler`, `TestScheduler`-tested), nesting auto-save suppression scopes, snapshot-based `BuildOptions` validation, and the save/export/import persistence flows with `OptionsPersistenceOutcome` results. Main keeps the option `[Reactive]` properties, the per-option `Apply*` UI projections (theme/font/TLS mutate Avalonia and service state), and the file pickers. Tests: `ApplicationOptionsWorkflowTests` + `ApplicationOptionsWorkflowPersistenceTests`.
+2. **Collections UI workflows** *(next)* — finish slice 3: move new/rename collection forms, inherited-headers sync + debounced autosave (~500 lines), filter/sort/display-mode, and import/delete into `CollectionsManagementCoordinator` or a new `CollectionsPanelViewModel`. Consider DynamicData for filter/sort here (see `docs/suggestions/DynamicDataCollections.md`).
 3. **Scheduled jobs workflow** — move `AddScheduledJob`/`RemoveScheduledJobAsync` and persistence hooks into a `ScheduledJobsWorkflow` next to `ScheduledJobService`.
 4. **Request tabs + history** — extract tab lifecycle (`NewRequestTab`, `CloseRequestTab`, `ApplyActiveRequestTab`, `SaveResponseStateForTab`) and history load/filter (`LoadHistoryAsync`, `ApplyHistoryFilter`, `LoadHistoryRequest`) into feature-scoped classes.
 5. **Layout management** — finish the layout slice: named layout save/restore/remove, window geometry, `PersistCurrentLayout`/`ApplyLayoutSnapshot`/`ReapplyStartupLayout` on top of the existing `LayoutWorkflow`/`LayoutTreeWorkflow`. Largest and riskiest; do it once the rest of Main is thin.

--- a/src/Arbor.HttpClient.Desktop.E2E.Tests/ApplicationOptionsWorkflowTests.cs
+++ b/src/Arbor.HttpClient.Desktop.E2E.Tests/ApplicationOptionsWorkflowTests.cs
@@ -170,8 +170,8 @@ public sealed class ApplicationOptionsWorkflowTests
     {
         using var workflow = new ApplicationOptionsWorkflow(CreateTempStore(), CreateSilentLogger(), new TestScheduler());
 
-        var outerScope = workflow.SuppressAutoSave();
-        var innerScope = workflow.SuppressAutoSave();
+        using var outerScope = workflow.SuppressAutoSave();
+        using var innerScope = workflow.SuppressAutoSave();
 
         innerScope.Dispose();
         workflow.IsAutoSaveSuppressed.Should().BeTrue();

--- a/src/Arbor.HttpClient.Desktop.E2E.Tests/ApplicationOptionsWorkflowTests.cs
+++ b/src/Arbor.HttpClient.Desktop.E2E.Tests/ApplicationOptionsWorkflowTests.cs
@@ -1,0 +1,389 @@
+using System.Reactive;
+using Arbor.HttpClient.Desktop.Features.Layout;
+using Arbor.HttpClient.Desktop.Features.Options;
+using Microsoft.Reactive.Testing;
+using Serilog;
+using Serilog.Core;
+
+namespace Arbor.HttpClient.Desktop.E2E.Tests;
+
+public sealed class ApplicationOptionsWorkflowTests
+{
+    private static ApplicationOptionsSnapshot CreateValidSnapshot() => new()
+    {
+        HttpVersion = "1.1",
+        TlsVersion = "SystemDefault",
+        EnableHttpDiagnostics = true,
+        DefaultContentType = "application/json",
+        FollowRedirects = false,
+        ShowRequestPreviewByDefault = true,
+        DefaultRequestUrl = "https://example.com/api",
+        ResponseSaveDefaultFolder = string.Empty,
+        ResponseSaveFileNamePattern = "{requestName}-{timestamp}",
+        DemoServerPort = 5000,
+        DemoServerHttpsPort = 5001,
+        DemoServerHttpEnabled = true,
+        DemoServerHttpsEnabled = false,
+        DefaultRequestTimeoutSeconds = 42,
+        Theme = "Dark",
+        FontFamily = "Consolas,Menlo,monospace",
+        FontSizeText = "14.5",
+        AutoStartScheduledJobsOnLaunch = false,
+        DefaultScheduledJobIntervalSeconds = 30,
+        CollectUnhandledExceptions = true
+    };
+
+    private static ILogger CreateSilentLogger() => Logger.None;
+
+    private static ApplicationOptionsStore CreateTempStore() =>
+        new(Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}", "options.json"));
+
+    [Fact]
+    public void BuildOptions_ValidSnapshot_MapsAllFields()
+    {
+        var snapshot = CreateValidSnapshot();
+        var layouts = new LayoutOptions();
+
+        var options = ApplicationOptionsWorkflow.BuildOptions(snapshot, layouts);
+
+        options.Http.HttpVersion.Should().Be("1.1");
+        options.Http.TlsVersion.Should().Be("SystemDefault");
+        options.Http.EnableHttpDiagnostics.Should().BeTrue();
+        options.Http.DefaultContentType.Should().Be("application/json");
+        options.Http.FollowRedirects.Should().BeFalse();
+        options.Http.ShowRequestPreviewByDefault.Should().BeTrue();
+        options.Http.DefaultRequestUrl.Should().Be("https://example.com/api");
+        options.Http.ResponseSaveFileNamePattern.Should().Be("{requestName}-{timestamp}");
+        options.Http.DemoServerPort.Should().Be(5000);
+        options.Http.DemoServerHttpsPort.Should().Be(5001);
+        options.Http.DemoServerHttpEnabled.Should().BeTrue();
+        options.Http.DemoServerHttpsEnabled.Should().BeFalse();
+        options.Http.DefaultRequestTimeoutSeconds.Should().Be(42);
+        options.Appearance.Theme.Should().Be("Dark");
+        options.Appearance.FontFamily.Should().Be("Consolas,Menlo,monospace");
+        options.Appearance.FontSize.Should().Be(14.5);
+        options.ScheduledJobs.AutoStartOnLaunch.Should().BeFalse();
+        options.ScheduledJobs.DefaultIntervalSeconds.Should().Be(30);
+        options.Diagnostics.CollectUnhandledExceptions.Should().BeTrue();
+        options.Layouts.Should().BeSameAs(layouts);
+    }
+
+    [Fact]
+    public void BuildOptions_NonNumericFontSize_ThrowsInvalidDataException()
+    {
+        var snapshot = CreateValidSnapshot() with { FontSizeText = "large" };
+
+        var act = () => ApplicationOptionsWorkflow.BuildOptions(snapshot, new LayoutOptions());
+
+        act.Should().Throw<InvalidDataException>().WithMessage("Font size must be a number.");
+    }
+
+    [Fact]
+    public void BuildOptions_ScheduledJobIntervalBelowOne_ClampsToOne()
+    {
+        var snapshot = CreateValidSnapshot() with { DefaultScheduledJobIntervalSeconds = 0 };
+
+        var options = ApplicationOptionsWorkflow.BuildOptions(snapshot, new LayoutOptions());
+
+        options.ScheduledJobs.DefaultIntervalSeconds.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildOptions_UnsupportedTlsVersion_ThrowsInvalidDataException()
+    {
+        var snapshot = CreateValidSnapshot() with { TlsVersion = "Ssl3" };
+
+        var act = () => ApplicationOptionsWorkflow.BuildOptions(snapshot, new LayoutOptions());
+
+        act.Should().Throw<InvalidDataException>().WithMessage("*TLS version*");
+    }
+
+    [Fact]
+    public void QueueAutoSave_WithStore_EmitsAfterThrottleInterval()
+    {
+        var scheduler = new TestScheduler();
+        using var workflow = new ApplicationOptionsWorkflow(CreateTempStore(), CreateSilentLogger(), scheduler);
+        var emitted = new List<Unit>();
+        using var subscription = workflow.AutoSaveRequested.Subscribe(emitted.Add);
+
+        workflow.QueueAutoSave();
+        scheduler.AdvanceBy(ApplicationOptionsWorkflow.AutoSaveThrottleInterval.Ticks - 1);
+        emitted.Should().BeEmpty();
+
+        scheduler.AdvanceBy(1);
+        emitted.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void QueueAutoSave_BurstWithinThrottleWindow_EmitsOnce()
+    {
+        var scheduler = new TestScheduler();
+        using var workflow = new ApplicationOptionsWorkflow(CreateTempStore(), CreateSilentLogger(), scheduler);
+        var emitted = new List<Unit>();
+        using var subscription = workflow.AutoSaveRequested.Subscribe(emitted.Add);
+
+        workflow.QueueAutoSave();
+        workflow.QueueAutoSave();
+        workflow.QueueAutoSave();
+        scheduler.AdvanceBy(ApplicationOptionsWorkflow.AutoSaveThrottleInterval.Ticks * 2);
+
+        emitted.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void QueueAutoSave_WithoutStore_DoesNotEmit()
+    {
+        var scheduler = new TestScheduler();
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger(), scheduler);
+        var emitted = new List<Unit>();
+        using var subscription = workflow.AutoSaveRequested.Subscribe(emitted.Add);
+
+        workflow.QueueAutoSave();
+        scheduler.AdvanceBy(ApplicationOptionsWorkflow.AutoSaveThrottleInterval.Ticks * 2);
+
+        emitted.Should().BeEmpty();
+        workflow.HasStore.Should().BeFalse();
+    }
+
+    [Fact]
+    public void QueueAutoSave_WhileSuppressed_DoesNotEmit()
+    {
+        var scheduler = new TestScheduler();
+        using var workflow = new ApplicationOptionsWorkflow(CreateTempStore(), CreateSilentLogger(), scheduler);
+        var emitted = new List<Unit>();
+        using var subscription = workflow.AutoSaveRequested.Subscribe(emitted.Add);
+
+        using (workflow.SuppressAutoSave())
+        {
+            workflow.IsAutoSaveSuppressed.Should().BeTrue();
+            workflow.QueueAutoSave();
+        }
+
+        scheduler.AdvanceBy(ApplicationOptionsWorkflow.AutoSaveThrottleInterval.Ticks * 2);
+
+        emitted.Should().BeEmpty();
+        workflow.IsAutoSaveSuppressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SuppressAutoSave_NestedScopes_ResumeOnlyAfterOutermostDisposed()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(CreateTempStore(), CreateSilentLogger(), new TestScheduler());
+
+        var outerScope = workflow.SuppressAutoSave();
+        var innerScope = workflow.SuppressAutoSave();
+
+        innerScope.Dispose();
+        workflow.IsAutoSaveSuppressed.Should().BeTrue();
+
+        outerScope.Dispose();
+        workflow.IsAutoSaveSuppressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Save_BuildThrows_ReturnsFailedOutcome()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+
+        var outcome = workflow.Save(
+            () => throw new InvalidDataException("Font size must be a number."),
+            _ => { });
+
+        outcome.IsSuccessful.Should().BeFalse();
+        outcome.ErrorMessage.Should().Be("Options could not be saved: Font size must be a number.");
+    }
+
+    [Fact]
+    public void Save_WithoutStore_StillInvokesOnSavedAndSucceeds()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+        ApplicationOptions? applied = null;
+
+        var outcome = workflow.Save(() => built, options => applied = options);
+
+        outcome.IsSuccessful.Should().BeTrue();
+        outcome.ErrorMessage.Should().BeEmpty();
+        applied.Should().BeSameAs(built);
+    }
+
+    [Fact]
+    public void Save_OnSavedThrows_ReturnsFailedOutcome()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+
+        var outcome = workflow.Save(() => built, _ => throw new InvalidOperationException("projection failed"));
+
+        outcome.IsSuccessful.Should().BeFalse();
+        outcome.ErrorMessage.Should().Be("Options could not be saved: projection failed");
+    }
+
+    [Fact]
+    public async Task ExportAsync_PickerCancelled_ReturnsSuccessWithoutExporting()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+
+        var outcome = await workflow.ExportAsync(() => built, () => Task.FromResult<string?>(null));
+
+        outcome.IsSuccessful.Should().BeTrue();
+        outcome.ErrorMessage.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExportAsync_BuildThrows_FailsWithoutInvokingPicker()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+        var pickerInvoked = false;
+
+        var outcome = await workflow.ExportAsync(
+            () => throw new InvalidDataException("Font size must be a number."),
+            () =>
+            {
+                pickerInvoked = true;
+                return Task.FromResult<string?>("unused.json");
+            });
+
+        outcome.IsSuccessful.Should().BeFalse();
+        outcome.ErrorMessage.Should().Be("Options export failed: Font size must be a number.");
+        pickerInvoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Import_WithoutStore_ReturnsFailedOutcome()
+    {
+        using var workflow = new ApplicationOptionsWorkflow(store: null, CreateSilentLogger());
+
+        var outcome = workflow.Import("anywhere.json", _ => { });
+
+        outcome.IsSuccessful.Should().BeFalse();
+        outcome.ErrorMessage.Should().Be("Options import failed: no options store is configured.");
+    }
+}
+
+[Trait("Category", "Integration")]
+public sealed class ApplicationOptionsWorkflowPersistenceTests
+{
+    private static ApplicationOptionsSnapshot CreateValidSnapshot() => new()
+    {
+        HttpVersion = "2.0",
+        TlsVersion = "Tls12",
+        EnableHttpDiagnostics = false,
+        DefaultContentType = "application/json",
+        FollowRedirects = true,
+        ShowRequestPreviewByDefault = false,
+        DefaultRequestUrl = "http://localhost:5000/echo",
+        ResponseSaveDefaultFolder = string.Empty,
+        ResponseSaveFileNamePattern = "{requestName}",
+        DemoServerPort = 5000,
+        DemoServerHttpsPort = 5001,
+        DemoServerHttpEnabled = true,
+        DemoServerHttpsEnabled = false,
+        DefaultRequestTimeoutSeconds = 100,
+        Theme = "Light",
+        FontFamily = "Consolas,Menlo,monospace",
+        FontSizeText = "13",
+        AutoStartScheduledJobsOnLaunch = true,
+        DefaultScheduledJobIntervalSeconds = 60,
+        CollectUnhandledExceptions = false
+    };
+
+    [Fact]
+    public void Save_WithStore_PersistsOptionsToDisk()
+    {
+        var optionsPath = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}", "options.json");
+        var store = new ApplicationOptionsStore(optionsPath);
+        using var workflow = new ApplicationOptionsWorkflow(store, Serilog.Core.Logger.None);
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+        ApplicationOptions? applied = null;
+
+        try
+        {
+            var outcome = workflow.Save(() => built, options => applied = options);
+
+            outcome.IsSuccessful.Should().BeTrue();
+            applied.Should().BeSameAs(built);
+            store.Load().Appearance.Theme.Should().Be("Light");
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(optionsPath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExportAsync_WithStore_WritesExportFile()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var store = new ApplicationOptionsStore(Path.Join(tempDir, "options.json"));
+        using var workflow = new ApplicationOptionsWorkflow(store, Serilog.Core.Logger.None);
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+        var exportPath = Path.Join(tempDir, "exported-options.json");
+
+        try
+        {
+            var outcome = await workflow.ExportAsync(() => built, () => Task.FromResult<string?>(exportPath));
+
+            outcome.IsSuccessful.Should().BeTrue();
+            File.Exists(exportPath).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Import_ExportedFile_RoundTripsAndInvokesOnImported()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var store = new ApplicationOptionsStore(Path.Join(tempDir, "options.json"));
+        using var workflow = new ApplicationOptionsWorkflow(store, Serilog.Core.Logger.None);
+        var built = ApplicationOptionsWorkflow.BuildOptions(CreateValidSnapshot(), new LayoutOptions());
+        var importPath = Path.Join(tempDir, "import-options.json");
+        store.Export(importPath, built);
+        ApplicationOptions? imported = null;
+
+        try
+        {
+            var outcome = workflow.Import(importPath, options => imported = options);
+
+            outcome.IsSuccessful.Should().BeTrue();
+            imported.Should().NotBeNull();
+            imported.Http.DefaultRequestTimeoutSeconds.Should().Be(100);
+            store.Load().Http.DefaultRequestTimeoutSeconds.Should().Be(100);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Import_InvalidJsonFile_ReturnsFailedOutcome()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var store = new ApplicationOptionsStore(Path.Join(tempDir, "options.json"));
+        using var workflow = new ApplicationOptionsWorkflow(store, Serilog.Core.Logger.None);
+        var importPath = Path.Join(tempDir, "invalid-options.json");
+        File.WriteAllText(importPath, "{ not valid json");
+        var onImportedInvoked = false;
+
+        try
+        {
+            var outcome = workflow.Import(importPath, _ => onImportedInvoked = true);
+
+            outcome.IsSuccessful.Should().BeFalse();
+            outcome.ErrorMessage.Should().StartWith("Options import failed: ");
+            onImportedInvoked.Should().BeFalse();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/src/Arbor.HttpClient.Desktop.E2E.Tests/Arbor.HttpClient.Desktop.E2E.Tests.csproj
+++ b/src/Arbor.HttpClient.Desktop.E2E.Tests/Arbor.HttpClient.Desktop.E2E.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Avalonia.Headless.XUnit" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.Reactive.Testing" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Include="coverlet.collector">

--- a/src/Arbor.HttpClient.Desktop.E2E.Tests/packages.lock.json
+++ b/src/Arbor.HttpClient.Desktop.E2E.Tests/packages.lock.json
@@ -44,6 +44,15 @@
         "resolved": "10.0.0",
         "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
+      "Microsoft.Reactive.Testing": {
+        "type": "Direct",
+        "requested": "[6.1.0, )",
+        "resolved": "6.1.0",
+        "contentHash": "1KLmcpM299ZSA8ZjCbXApM/TVeaJJGZZz8nEJ8SWszf/JYcPqhzeg5s2rhCBIWuSoBaga3lny4EATs4fi/ME5A==",
+        "dependencies": {
+          "System.Reactive": "6.1.0"
+        }
+      },
       "ReactiveUI": {
         "type": "Direct",
         "requested": "[23.2.28, )",

--- a/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
@@ -115,9 +115,8 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     private readonly Dictionary<string, DockLayoutSnapshot> _savedLayouts = new(StringComparer.OrdinalIgnoreCase);
     private int _layoutNameCounter = 1;
     private bool _suppressLayoutRestore;
-    private bool _suppressOptionsAutoSave;
     private CancellationTokenSource? _sendRequestCts;
-    private readonly Subject<Unit> _optionsAutoSaveRequestedSubject = new();
+    private ApplicationOptionsWorkflow _optionsWorkflow = null!;
     private readonly CompositeDisposable _optionsAutoSaveDisposables = new();
     private bool _suppressCollectionInheritedHeadersAutoSave;
     private bool _suppressCollectionInheritedHeadersLivePreviewSync;
@@ -709,8 +708,8 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
             .Throttle(TimeSpan.FromSeconds(1))
             .Subscribe(snapshot => Dispatcher.UIThread.Post(() => TriggerCollectionInheritedHeadersAutoSave(snapshot))));
 
-        _optionsAutoSaveDisposables.Add(_optionsAutoSaveRequestedSubject
-            .Throttle(TimeSpan.FromSeconds(1))
+        _optionsWorkflow = new ApplicationOptionsWorkflow(_applicationOptionsStore, _debugLogger);
+        _optionsAutoSaveDisposables.Add(_optionsWorkflow.AutoSaveRequested
             .Subscribe(_ => Dispatcher.UIThread.Post(SaveOptions)));
 
         _optionsAutoSaveDisposables.Add(Observable
@@ -1292,53 +1291,32 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     public System.Windows.Input.ICommand NewEnvironmentCommand => _environmentsViewModel.NewEnvironmentCommand;
     public System.Windows.Input.ICommand ExportEnvironmentsCommand => _environmentsViewModel.ExportEnvironmentsCommand;
 
-    private ApplicationOptions BuildOptionsFromCurrentState()
+    private ApplicationOptions BuildOptionsFromCurrentState() =>
+        ApplicationOptionsWorkflow.BuildOptions(BuildOptionsSnapshot(), BuildLayoutOptions());
+
+    private ApplicationOptionsSnapshot BuildOptionsSnapshot() => new()
     {
-        if (!double.TryParse(UiFontSizeText, NumberStyles.Float, CultureInfo.InvariantCulture, out var fontSize))
-        {
-            throw new InvalidDataException("Font size must be a number.");
-        }
-
-        var options = new ApplicationOptions
-        {
-            Http = new HttpOptions
-            {
-                HttpVersion = _requestEditor.SelectedHttpVersionOption,
-                TlsVersion = SelectedTlsVersionOption,
-                EnableHttpDiagnostics = EnableHttpDiagnostics,
-                DefaultContentType = DefaultContentType,
-                FollowRedirects = FollowHttpRedirects,
-                ShowRequestPreviewByDefault = ShowRequestPreviewByDefault,
-                DefaultRequestUrl = DefaultRequestUrl,
-                ResponseSaveDefaultFolder = ResponseSaveDefaultFolder,
-                ResponseSaveFileNamePattern = ResponseSaveFileNamePattern,
-                DemoServerPort = DemoServerPort,
-                DemoServerHttpsPort = DemoServerHttpsPort,
-                DemoServerHttpEnabled = IsDemoServerHttpEnabled,
-                DemoServerHttpsEnabled = IsDemoServerHttpsEnabled,
-                DefaultRequestTimeoutSeconds = DefaultRequestTimeoutSeconds
-            },
-            Appearance = new AppearanceOptions
-            {
-                Theme = SelectedThemeOption,
-                FontFamily = UiFontFamily,
-                FontSize = fontSize
-            },
-            ScheduledJobs = new ScheduledJobsOptions
-            {
-                AutoStartOnLaunch = AutoStartScheduledJobsOnLaunch,
-                DefaultIntervalSeconds = Math.Max(1, DefaultScheduledJobIntervalSeconds)
-            },
-            Layouts = BuildLayoutOptions(),
-            Diagnostics = new DiagnosticsOptions
-            {
-                CollectUnhandledExceptions = CollectUnhandledExceptions
-            }
-        };
-
-        ApplicationOptionsStore.Validate(options);
-        return options;
-    }
+        HttpVersion = _requestEditor.SelectedHttpVersionOption,
+        TlsVersion = SelectedTlsVersionOption,
+        EnableHttpDiagnostics = EnableHttpDiagnostics,
+        DefaultContentType = DefaultContentType,
+        FollowRedirects = FollowHttpRedirects,
+        ShowRequestPreviewByDefault = ShowRequestPreviewByDefault,
+        DefaultRequestUrl = DefaultRequestUrl,
+        ResponseSaveDefaultFolder = ResponseSaveDefaultFolder,
+        ResponseSaveFileNamePattern = ResponseSaveFileNamePattern,
+        DemoServerPort = DemoServerPort,
+        DemoServerHttpsPort = DemoServerHttpsPort,
+        DemoServerHttpEnabled = IsDemoServerHttpEnabled,
+        DemoServerHttpsEnabled = IsDemoServerHttpsEnabled,
+        DefaultRequestTimeoutSeconds = DefaultRequestTimeoutSeconds,
+        Theme = SelectedThemeOption,
+        FontFamily = UiFontFamily,
+        FontSizeText = UiFontSizeText,
+        AutoStartScheduledJobsOnLaunch = AutoStartScheduledJobsOnLaunch,
+        DefaultScheduledJobIntervalSeconds = DefaultScheduledJobIntervalSeconds,
+        CollectUnhandledExceptions = CollectUnhandledExceptions
+    };
 
     private void ApplyOptions(ApplicationOptions options, bool updateCurrentRequestUrl = true)
     {
@@ -1346,46 +1324,38 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         var previousDefaultUrl = _applicationOptions.Http.DefaultRequestUrl;
         _applicationOptions = options;
 
-        var previousSuppressOptionsAutoSave = _suppressOptionsAutoSave;
-        _suppressOptionsAutoSave = true;
+        using var autoSaveSuppression = _optionsWorkflow.SuppressAutoSave();
 
-        try
+        SelectedThemeOption = options.Appearance.Theme;
+        _requestEditor.SelectedHttpVersionOption = options.Http.HttpVersion;
+        SelectedTlsVersionOption = options.Http.TlsVersion;
+        EnableHttpDiagnostics = options.Http.EnableHttpDiagnostics;
+        FollowHttpRedirects = options.Http.FollowRedirects;
+        ShowRequestPreviewByDefault = options.Http.ShowRequestPreviewByDefault;
+        DefaultRequestUrl = options.Http.DefaultRequestUrl;
+        DefaultContentType = options.Http.DefaultContentType;
+        DefaultRequestTimeoutSeconds = options.Http.DefaultRequestTimeoutSeconds;
+        ResponseSaveDefaultFolder = options.Http.ResponseSaveDefaultFolder;
+        ResponseSaveFileNamePattern = options.Http.ResponseSaveFileNamePattern;
+        _requestEditor.DefaultContentType = options.Http.DefaultContentType;
+        UiFontFamily = options.Appearance.FontFamily;
+        UiFontSizeText = options.Appearance.FontSize.ToString("0.##", CultureInfo.InvariantCulture);
+        AutoStartScheduledJobsOnLaunch = options.ScheduledJobs.AutoStartOnLaunch;
+        DefaultScheduledJobIntervalSeconds = options.ScheduledJobs.DefaultIntervalSeconds;
+        DemoServerPort = options.Http.DemoServerPort;
+        DemoServerHttpsPort = options.Http.DemoServerHttpsPort;
+        IsDemoServerHttpEnabled = options.Http.DemoServerHttpEnabled;
+        IsDemoServerHttpsEnabled = options.Http.DemoServerHttpsEnabled;
+        CollectUnhandledExceptions = options.Diagnostics.CollectUnhandledExceptions;
+
+        if (_requestEditor.FollowRedirectsForRequest == previousDefaultFollowRedirects)
         {
-            SelectedThemeOption = options.Appearance.Theme;
-            _requestEditor.SelectedHttpVersionOption = options.Http.HttpVersion;
-            SelectedTlsVersionOption = options.Http.TlsVersion;
-            EnableHttpDiagnostics = options.Http.EnableHttpDiagnostics;
-            FollowHttpRedirects = options.Http.FollowRedirects;
-            ShowRequestPreviewByDefault = options.Http.ShowRequestPreviewByDefault;
-            DefaultRequestUrl = options.Http.DefaultRequestUrl;
-            DefaultContentType = options.Http.DefaultContentType;
-            DefaultRequestTimeoutSeconds = options.Http.DefaultRequestTimeoutSeconds;
-            ResponseSaveDefaultFolder = options.Http.ResponseSaveDefaultFolder;
-            ResponseSaveFileNamePattern = options.Http.ResponseSaveFileNamePattern;
-            _requestEditor.DefaultContentType = options.Http.DefaultContentType;
-            UiFontFamily = options.Appearance.FontFamily;
-            UiFontSizeText = options.Appearance.FontSize.ToString("0.##", CultureInfo.InvariantCulture);
-            AutoStartScheduledJobsOnLaunch = options.ScheduledJobs.AutoStartOnLaunch;
-            DefaultScheduledJobIntervalSeconds = options.ScheduledJobs.DefaultIntervalSeconds;
-            DemoServerPort = options.Http.DemoServerPort;
-            DemoServerHttpsPort = options.Http.DemoServerHttpsPort;
-            IsDemoServerHttpEnabled = options.Http.DemoServerHttpEnabled;
-            IsDemoServerHttpsEnabled = options.Http.DemoServerHttpsEnabled;
-            CollectUnhandledExceptions = options.Diagnostics.CollectUnhandledExceptions;
-
-            if (_requestEditor.FollowRedirectsForRequest == previousDefaultFollowRedirects)
-            {
-                _requestEditor.FollowRedirectsForRequest = options.Http.FollowRedirects;
-            }
-
-            if (updateCurrentRequestUrl || string.IsNullOrWhiteSpace(_requestEditor.RequestUrl) || string.Equals(_requestEditor.RequestUrl, previousDefaultUrl, StringComparison.Ordinal))
-            {
-                _requestEditor.RequestUrl = options.Http.DefaultRequestUrl;
-            }
+            _requestEditor.FollowRedirectsForRequest = options.Http.FollowRedirects;
         }
-        finally
+
+        if (updateCurrentRequestUrl || string.IsNullOrWhiteSpace(_requestEditor.RequestUrl) || string.Equals(_requestEditor.RequestUrl, previousDefaultUrl, StringComparison.Ordinal))
         {
-            _suppressOptionsAutoSave = previousSuppressOptionsAutoSave;
+            _requestEditor.RequestUrl = options.Http.DefaultRequestUrl;
         }
     }
 
@@ -2384,19 +2354,18 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     [ReactiveCommand]
     private void SaveOptions()
     {
-        try
+        ErrorMessage = string.Empty;
+        var outcome = _optionsWorkflow.Save(BuildOptionsFromCurrentState, ApplySavedOptions);
+        if (!outcome.IsSuccessful)
         {
-            ErrorMessage = string.Empty;
-            var options = BuildOptionsFromCurrentState();
-            _applicationOptionsStore?.Save(options);
-            ApplyOptions(options, updateCurrentRequestUrl: false);
-            _onApplicationOptionsChanged?.Invoke(options);
-            _debugLogger.Information("Saved application options");
+            ErrorMessage = outcome.ErrorMessage;
         }
-        catch (Exception exception)
-        {
-            ErrorMessage = $"Options could not be saved: {exception.Message}";
-        }
+    }
+
+    private void ApplySavedOptions(ApplicationOptions options)
+    {
+        ApplyOptions(options, updateCurrentRequestUrl: false);
+        _onApplicationOptionsChanged?.Invoke(options);
     }
 
     [ReactiveCommand]
@@ -2407,41 +2376,36 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
             return;
         }
 
-        try
+        ErrorMessage = string.Empty;
+        var outcome = await _optionsWorkflow.ExportAsync(BuildOptionsFromCurrentState, PickOptionsExportPathAsync);
+        if (!outcome.IsSuccessful)
         {
-            ErrorMessage = string.Empty;
-            var options = BuildOptionsFromCurrentState();
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-            {
-                Title = "Export Options",
-                SuggestedFileName = "arbor-options.json",
-                FileTypeChoices =
-                [
-                    new FilePickerFileType("JSON")
-                    {
-                        Patterns = ["*.json"]
-                    }
-                ]
-            });
-
-            if (file is null)
-            {
-                return;
-            }
-
-            _applicationOptionsStore?.Export(file.Path.LocalPath, options);
-            _debugLogger.Information("Exported options to {Path}", file.Path.LocalPath);
+            ErrorMessage = outcome.ErrorMessage;
         }
-        catch (Exception exception)
+    }
+
+    private async Task<string?> PickOptionsExportPathAsync()
+    {
+        var file = await StorageProvider!.SaveFilePickerAsync(new FilePickerSaveOptions
         {
-            ErrorMessage = $"Options export failed: {exception.Message}";
-        }
+            Title = "Export Options",
+            SuggestedFileName = "arbor-options.json",
+            FileTypeChoices =
+            [
+                new FilePickerFileType("JSON")
+                {
+                    Patterns = ["*.json"]
+                }
+            ]
+        });
+
+        return file?.Path.LocalPath;
     }
 
     [ReactiveCommand]
     private async Task ImportOptionsAsync()
     {
-        if (StorageProvider is null || _applicationOptionsStore is null)
+        if (StorageProvider is null || !_optionsWorkflow.HasStore)
         {
             return;
         }
@@ -2464,18 +2428,11 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
             return;
         }
 
-        try
+        ErrorMessage = string.Empty;
+        var outcome = _optionsWorkflow.Import(files[0].Path.LocalPath, ApplySavedOptions);
+        if (!outcome.IsSuccessful)
         {
-            ErrorMessage = string.Empty;
-            var options = _applicationOptionsStore.Import(files[0].Path.LocalPath);
-            _applicationOptionsStore.Save(options);
-            ApplyOptions(options, updateCurrentRequestUrl: false);
-            _onApplicationOptionsChanged?.Invoke(options);
-            _debugLogger.Information("Imported options from {Path}", files[0].Path.LocalPath);
-        }
-        catch (Exception exception)
-        {
-            ErrorMessage = $"Options import failed: {exception.Message}";
+            ErrorMessage = outcome.ErrorMessage;
         }
     }
 
@@ -2568,7 +2525,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         _historyFilterDisposables.Dispose();
         _collectionSearchFilterRequestedSubject.OnCompleted();
         _collectionSearchFilterDisposables.Dispose();
-        _optionsAutoSaveRequestedSubject.OnCompleted();
+        _optionsWorkflow.Dispose();
         _optionsAutoSaveDisposables.Dispose();
         _collectionInheritedHeadersAutoSaveRequestedSubject.OnCompleted();
         _collectionInheritedHeadersAutoSaveDisposables.Dispose();
@@ -3306,15 +3263,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         }
     }
 
-    private void QueueOptionsAutoSave()
-    {
-        if (_suppressOptionsAutoSave || _applicationOptionsStore is null)
-        {
-            return;
-        }
-
-        _optionsAutoSaveRequestedSubject.OnNext(Unit.Default);
-    }
+    private void QueueOptionsAutoSave() => _optionsWorkflow.QueueAutoSave();
 
 
     private async Task LoadScheduledJobsAsync(CancellationToken cancellationToken = default)

--- a/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
@@ -116,7 +116,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     private int _layoutNameCounter = 1;
     private bool _suppressLayoutRestore;
     private CancellationTokenSource? _sendRequestCts;
-    private ApplicationOptionsWorkflow _optionsWorkflow = null!;
+    private readonly ApplicationOptionsWorkflow _optionsWorkflow;
     private readonly CompositeDisposable _optionsAutoSaveDisposables = new();
     private bool _suppressCollectionInheritedHeadersAutoSave;
     private bool _suppressCollectionInheritedHeadersLivePreviewSync;

--- a/src/Arbor.HttpClient.Desktop/Features/Options/ApplicationOptionsWorkflow.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/Options/ApplicationOptionsWorkflow.cs
@@ -1,0 +1,278 @@
+using System.Globalization;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Arbor.HttpClient.Desktop.Features.Diagnostics;
+using Arbor.HttpClient.Desktop.Features.Layout;
+using Arbor.HttpClient.Desktop.Features.ScheduledJobs;
+using Serilog;
+
+namespace Arbor.HttpClient.Desktop.Features.Options;
+
+/// <summary>
+/// Owns application-options persistence: debounced auto-save scheduling, building a validated
+/// <see cref="ApplicationOptions"/> from a UI state snapshot, and the save/export/import flows.
+/// Projecting saved options back onto view-model state stays with the host view model and is
+/// passed in as a callback so failures surface through the returned outcome.
+/// </summary>
+public sealed class ApplicationOptionsWorkflow : IDisposable
+{
+    public static readonly TimeSpan AutoSaveThrottleInterval = TimeSpan.FromSeconds(1);
+
+    private readonly ApplicationOptionsStore? _store;
+    private readonly ILogger _debugLogger;
+    private readonly Subject<Unit> _autoSaveRequestedSubject = new();
+    private readonly IObservable<Unit> _autoSaveRequested;
+    private int _autoSaveSuppressionDepth;
+
+    public ApplicationOptionsWorkflow(
+        ApplicationOptionsStore? store,
+        ILogger debugLogger,
+        IScheduler? autoSaveScheduler = null)
+    {
+        _store = store;
+        _debugLogger = debugLogger;
+        _autoSaveRequested = _autoSaveRequestedSubject
+            .Throttle(AutoSaveThrottleInterval, autoSaveScheduler ?? DefaultScheduler.Instance);
+    }
+
+    /// <summary>True when an options store is configured so persistence operations can run.</summary>
+    public bool HasStore => _store is not null;
+
+    /// <summary>
+    /// Debounced stream of auto-save requests. The subscriber is responsible for marshalling
+    /// the actual save onto the UI thread.
+    /// </summary>
+    public IObservable<Unit> AutoSaveRequested => _autoSaveRequested;
+
+    public bool IsAutoSaveSuppressed => Volatile.Read(ref _autoSaveSuppressionDepth) > 0;
+
+    /// <summary>
+    /// Suppresses auto-save queuing until the returned scope is disposed. Scopes may nest;
+    /// auto-save resumes when the outermost scope is disposed.
+    /// </summary>
+    public IDisposable SuppressAutoSave()
+    {
+        Interlocked.Increment(ref _autoSaveSuppressionDepth);
+        return Disposable.Create(() => Interlocked.Decrement(ref _autoSaveSuppressionDepth));
+    }
+
+    /// <summary>
+    /// Requests a debounced auto-save. No-op while suppressed or when no store is configured.
+    /// </summary>
+    public void QueueAutoSave()
+    {
+        if (IsAutoSaveSuppressed || _store is null)
+        {
+            return;
+        }
+
+        _autoSaveRequestedSubject.OnNext(Unit.Default);
+    }
+
+    /// <summary>
+    /// Builds a validated <see cref="ApplicationOptions"/> from the snapshot. Throws
+    /// <see cref="InvalidDataException"/> when the font size is not a number and propagates
+    /// validation failures from <see cref="ApplicationOptionsStore.Validate"/>.
+    /// </summary>
+    public static ApplicationOptions BuildOptions(ApplicationOptionsSnapshot snapshot, LayoutOptions layouts)
+    {
+        if (!double.TryParse(snapshot.FontSizeText, NumberStyles.Float, CultureInfo.InvariantCulture, out var fontSize))
+        {
+            throw new InvalidDataException("Font size must be a number.");
+        }
+
+        var options = new ApplicationOptions
+        {
+            Http = new HttpOptions
+            {
+                HttpVersion = snapshot.HttpVersion,
+                TlsVersion = snapshot.TlsVersion,
+                EnableHttpDiagnostics = snapshot.EnableHttpDiagnostics,
+                DefaultContentType = snapshot.DefaultContentType,
+                FollowRedirects = snapshot.FollowRedirects,
+                ShowRequestPreviewByDefault = snapshot.ShowRequestPreviewByDefault,
+                DefaultRequestUrl = snapshot.DefaultRequestUrl,
+                ResponseSaveDefaultFolder = snapshot.ResponseSaveDefaultFolder,
+                ResponseSaveFileNamePattern = snapshot.ResponseSaveFileNamePattern,
+                DemoServerPort = snapshot.DemoServerPort,
+                DemoServerHttpsPort = snapshot.DemoServerHttpsPort,
+                DemoServerHttpEnabled = snapshot.DemoServerHttpEnabled,
+                DemoServerHttpsEnabled = snapshot.DemoServerHttpsEnabled,
+                DefaultRequestTimeoutSeconds = snapshot.DefaultRequestTimeoutSeconds
+            },
+            Appearance = new AppearanceOptions
+            {
+                Theme = snapshot.Theme,
+                FontFamily = snapshot.FontFamily,
+                FontSize = fontSize
+            },
+            ScheduledJobs = new ScheduledJobsOptions
+            {
+                AutoStartOnLaunch = snapshot.AutoStartScheduledJobsOnLaunch,
+                DefaultIntervalSeconds = Math.Max(1, snapshot.DefaultScheduledJobIntervalSeconds)
+            },
+            Layouts = layouts,
+            Diagnostics = new DiagnosticsOptions
+            {
+                CollectUnhandledExceptions = snapshot.CollectUnhandledExceptions
+            }
+        };
+
+        ApplicationOptionsStore.Validate(options);
+        return options;
+    }
+
+    /// <summary>
+    /// Builds, persists, and re-applies the current options. <paramref name="onSaved"/> runs
+    /// inside the failure boundary so projection errors also surface as a failed outcome.
+    /// </summary>
+    public OptionsPersistenceOutcome Save(
+        Func<ApplicationOptions> buildOptions,
+        Action<ApplicationOptions> onSaved)
+    {
+        try
+        {
+            var options = buildOptions();
+            _store?.Save(options);
+            onSaved(options);
+            _debugLogger.Information("Saved application options");
+            return OptionsPersistenceOutcome.Success();
+        }
+        // Persistence failures must surface as an error message instead of crashing the app;
+        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
+        catch (Exception exception)
+        {
+            return OptionsPersistenceOutcome.Failed($"Options could not be saved: {exception.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Builds the current options and exports them to the path produced by
+    /// <paramref name="pickExportPath"/>. A null path (picker cancelled) is a silent success.
+    /// </summary>
+    public async Task<OptionsPersistenceOutcome> ExportAsync(
+        Func<ApplicationOptions> buildOptions,
+        Func<Task<string?>> pickExportPath)
+    {
+        try
+        {
+            var options = buildOptions();
+            var exportPath = await pickExportPath();
+            if (exportPath is null)
+            {
+                return OptionsPersistenceOutcome.Success();
+            }
+
+            _store?.Export(exportPath, options);
+            _debugLogger.Information("Exported options to {Path}", exportPath);
+            return OptionsPersistenceOutcome.Success();
+        }
+        // Persistence failures must surface as an error message instead of crashing the app;
+        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
+        catch (Exception exception)
+        {
+            return OptionsPersistenceOutcome.Failed($"Options export failed: {exception.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Imports options from <paramref name="path"/>, persists them, and invokes
+    /// <paramref name="onImported"/> inside the failure boundary.
+    /// </summary>
+    public OptionsPersistenceOutcome Import(string path, Action<ApplicationOptions> onImported)
+    {
+        if (_store is null)
+        {
+            return OptionsPersistenceOutcome.Failed("Options import failed: no options store is configured.");
+        }
+
+        try
+        {
+            var options = _store.Import(path);
+            _store.Save(options);
+            onImported(options);
+            _debugLogger.Information("Imported options from {Path}", path);
+            return OptionsPersistenceOutcome.Success();
+        }
+        // Persistence failures must surface as an error message instead of crashing the app;
+        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
+        catch (Exception exception)
+        {
+            return OptionsPersistenceOutcome.Failed($"Options import failed: {exception.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        _autoSaveRequestedSubject.OnCompleted();
+        _autoSaveRequestedSubject.Dispose();
+    }
+}
+
+/// <summary>
+/// Immutable snapshot of the option-related view-model state used to build
+/// an <see cref="ApplicationOptions"/> instance.
+/// </summary>
+public sealed record ApplicationOptionsSnapshot
+{
+    public required string HttpVersion { get; init; }
+
+    public required string TlsVersion { get; init; }
+
+    public required bool EnableHttpDiagnostics { get; init; }
+
+    public required string DefaultContentType { get; init; }
+
+    public required bool FollowRedirects { get; init; }
+
+    public required bool ShowRequestPreviewByDefault { get; init; }
+
+    public required string DefaultRequestUrl { get; init; }
+
+    public required string ResponseSaveDefaultFolder { get; init; }
+
+    public required string ResponseSaveFileNamePattern { get; init; }
+
+    public required int DemoServerPort { get; init; }
+
+    public required int DemoServerHttpsPort { get; init; }
+
+    public required bool DemoServerHttpEnabled { get; init; }
+
+    public required bool DemoServerHttpsEnabled { get; init; }
+
+    public required int DefaultRequestTimeoutSeconds { get; init; }
+
+    public required string Theme { get; init; }
+
+    public required string FontFamily { get; init; }
+
+    public required string FontSizeText { get; init; }
+
+    public required bool AutoStartScheduledJobsOnLaunch { get; init; }
+
+    public required int DefaultScheduledJobIntervalSeconds { get; init; }
+
+    public required bool CollectUnhandledExceptions { get; init; }
+}
+
+/// <summary>Result of a save/export/import operation on application options.</summary>
+public sealed record OptionsPersistenceOutcome
+{
+    private OptionsPersistenceOutcome(bool isSuccessful, string errorMessage)
+    {
+        IsSuccessful = isSuccessful;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccessful { get; }
+
+    public string ErrorMessage { get; }
+
+    public static OptionsPersistenceOutcome Success() => new(true, string.Empty);
+
+    public static OptionsPersistenceOutcome Failed(string errorMessage) => new(false, errorMessage);
+}

--- a/src/Arbor.HttpClient.Desktop/Features/Options/ApplicationOptionsWorkflow.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/Options/ApplicationOptionsWorkflow.cs
@@ -141,9 +141,7 @@ public sealed class ApplicationOptionsWorkflow : IDisposable
             _debugLogger.Information("Saved application options");
             return OptionsPersistenceOutcome.Success();
         }
-        // Persistence failures must surface as an error message instead of crashing the app;
-        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not OutOfMemoryException)
         {
             return OptionsPersistenceOutcome.Failed($"Options could not be saved: {exception.Message}");
         }
@@ -170,9 +168,7 @@ public sealed class ApplicationOptionsWorkflow : IDisposable
             _debugLogger.Information("Exported options to {Path}", exportPath);
             return OptionsPersistenceOutcome.Success();
         }
-        // Persistence failures must surface as an error message instead of crashing the app;
-        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not OutOfMemoryException)
         {
             return OptionsPersistenceOutcome.Failed($"Options export failed: {exception.Message}");
         }
@@ -197,9 +193,7 @@ public sealed class ApplicationOptionsWorkflow : IDisposable
             _debugLogger.Information("Imported options from {Path}", path);
             return OptionsPersistenceOutcome.Success();
         }
-        // Persistence failures must surface as an error message instead of crashing the app;
-        // the exception set (validation, IO, serialization) is open-ended, so no filter is applied.
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not OutOfMemoryException)
         {
             return OptionsPersistenceOutcome.Failed($"Options import failed: {exception.Message}");
         }


### PR DESCRIPTION
- Record extraction status: request execution, response projection/actions,
  GraphQL, streaming, and demo-server slices done; collections and layout
  partial; options, scheduled jobs, tabs/history not started
- Document the established Workflow/Coordinator extraction convention
- Update communication-pattern guidance post-ReactiveUI migration: direct
  coordinator calls for command flows, IObservable endpoints for fan-out,
  Interaction for dialogs, DynamicData for collection filtering; reject
  event aggregator/MessageBus and mediator
- Add ordered plan for remaining slices (next: Options workflow); defer
  DockFactory feature registrations until after slice extraction
- Sync folder-structure listing with actual Core/Desktop layout

https://claude.ai/code/session_0121KS2w48nDc536M68VLgYi