### PR TITLE
Extract scheduled-jobs lifecycle from MainWindowViewModel into ScheduledJobsWorkflow

### DIFF
--- a/docs/architecture/clean-feature-separation.md
+++ b/docs/architecture/clean-feature-separation.md
@@ -12,7 +12,7 @@ This document answers the architecture questions raised in [issue #33](https://g
 
 ## Findings
 
-> **Update 2026-06-12:** extraction is well underway. Request execution (HTTP/GraphQL/WebSocket/SSE), response projection, response actions, the demo-server lifecycle, options persistence (auto-save/save/export/import via `ApplicationOptionsWorkflow`), and the collections workflows (management incl. import/delete via `CollectionsManagementCoordinator`, inherited-headers autosave via `CollectionInheritedHeadersWorkflow`, filter/sort/group via `CollectionFilterWorkflow`) now live in feature-scoped Workflow/Coordinator classes; layout is partially extracted. `MainWindowViewModel` still owns the per-option UI projections, named-layout management, request tabs, history, and scheduled-job commands. Current status and the ordered forward plan live in [`mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md). The findings below describe the original state and are kept for context.
+> **Update 2026-06-12:** extraction is well underway. Request execution (HTTP/GraphQL/WebSocket/SSE), response projection, response actions, the demo-server lifecycle, options persistence (auto-save/save/export/import via `ApplicationOptionsWorkflow`), the collections workflows (management incl. import/delete via `CollectionsManagementCoordinator`, inherited-headers autosave via `CollectionInheritedHeadersWorkflow`, filter/sort/group via `CollectionFilterWorkflow`), and the scheduled-jobs lifecycle (add/remove/load incl. auto-start via `ScheduledJobsWorkflow`) now live in feature-scoped Workflow/Coordinator classes; layout is partially extracted. `MainWindowViewModel` still owns the per-option UI projections, named-layout management, request tabs, and history. Current status and the ordered forward plan live in [`mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md). The findings below describe the original state and are kept for context.
 
 - **Monolithic main view model**: `MainWindowViewModel` (~2,500 lines at the time of writing) owns request editing, response rendering, history, collections, environments, options, scheduling, layout persistence, and logging. All UI actions pass through this single type, so responsibilities are tightly coupled.
 - **Child view models are thin proxies**: dockable VMs such as `RequestViewModel`, `ResponseViewModel`, `LeftPanelViewModel`, and `OptionsViewModel` simply forward to `MainWindowViewModel`. Reusing them elsewhere still drags the entire main VM with it.
@@ -111,7 +111,7 @@ Features/
                             OptionsViewModel, OptionsView, per-page option views (HttpOptionsPageView,
                             LookAndFeelOptionsPageView, DiagnosticsOptionsPageView, ManageOptionsPageView,
                             ScheduledJobsOptionsPageView)
-  ScheduledJobs/          — ScheduledJobService, ScheduledJobViewModel, ScheduledJobsOptions
+  ScheduledJobs/          — ScheduledJobService, ScheduledJobsWorkflow, ScheduledJobViewModel, ScheduledJobsOptions
   Scripting/              — RoslynScriptRunner, ScriptViewModel
   Sse/                    — SseViewModel
   Streaming/              — StreamingConnectionWorkflow
@@ -135,7 +135,7 @@ Shared/                   — ReactiveViewModelBase, ReactiveToolBase, Disposabl
 
 ## Ordered next steps
 
-0. Use the execution plan in [`docs/architecture/mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md) for incremental extraction work and communication-pattern decisions — see its "Remaining slices — ordered plan" section for the current slice order (next up: Scheduled jobs workflow).
+0. Use the execution plan in [`docs/architecture/mainwindowviewmodel-split-plan.md`](mainwindowviewmodel-split-plan.md) for incremental extraction work and communication-pattern decisions — see its "Remaining slices — ordered plan" section for the current slice order (next up: Request tabs + history).
 1. ~~Feature-centric folder structure~~ ✅ Complete — all projects now use vertical-slice feature folders.
 2. Refactor `DockFactory` to consume feature registrations and stop requiring a `MainWindowViewModel` reference. **Decision 2026-06-11: deliberately deferred until after the remaining `MainWindowViewModel` slices are extracted**, so registrations can target clean feature VMs.
 3. ~~Evaluate whether a mediator/event-bus is needed after 1–2 successful slice extractions.~~ ✅ Resolved — several extractions later, direct Workflow/Coordinator calls plus `IObservable<T>` endpoints cover all communication needs; mediator/event-bus rejected (see the split plan's "Current guidance" section).

--- a/docs/architecture/mainwindowviewmodel-split-plan.md
+++ b/docs/architecture/mainwindowviewmodel-split-plan.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-`MainWindowViewModel` contains multiple feature areas and coordination responsibilities in one class (about 4,000 lines when this plan was written; about 3,140 lines as of 2026-06-12). This slows down feature work, increases regression risk, and makes focused testing harder.
+`MainWindowViewModel` contains multiple feature areas and coordination responsibilities in one class (about 4,000 lines when this plan was written; about 3,090 lines as of 2026-06-12 after the scheduled-jobs slice). This slows down feature work, increases regression risk, and makes focused testing harder.
 
 This document is a persisted implementation plan for splitting feature logic from `MainWindowViewModel` while keeping behavior stable.
 
@@ -93,7 +93,7 @@ Recommended extraction order (lowest coupling first):
 1. ✅ Response actions (copy/save/open external) — see below
 2. ✅ Demo server lifecycle — `DemoDataWorkflow` + `DemoServerLifecycleCoordinator` (`Features/Demo/`)
 3. ✅ Collections workflows — `CollectionsWorkflow` + `CollectionsManagementCoordinator` (create/rename/add/import/delete), `CollectionInheritedHeadersWorkflow` (debounced autosave + persistence), and `CollectionFilterWorkflow` (filter/sort/group) in `Features/Collections/`; Main keeps form-visibility state and editor live-preview projection
-4. Scheduled jobs workflows — `ScheduledJobService` exists, but add/remove commands and persistence hooks are still in `MainWindowViewModel`
+4. ✅ Scheduled jobs workflows — `ScheduledJobsWorkflow` (`Features/ScheduledJobs/`) owns the job-list lifecycle (add/remove/load incl. auto-start on launch); Main keeps the `[ReactiveCommand]` entry points and left-panel tab state
 5. ✅ Request execution orchestration — `HttpRequestWorkflow` + `ManualHttpRequestCoordinator` + `HttpResponseProjectionWorkflow` (`Features/HttpRequest/`), `GraphQlRequestWorkflow` + `ManualGraphQlRequestCoordinator` (`Features/GraphQl/`), `StreamingConnectionWorkflow` (`Features/Streaming/`)
 6. Draft/options autosave orchestration — options `Apply*`/save/import/export and the autosave subjects are still in `MainWindowViewModel`; layout has partial extraction via `LayoutWorkflow` + `LayoutTreeWorkflow` (`Features/Layout/`)
 
@@ -113,7 +113,7 @@ Recommended extraction order (lowest coupling first):
 | Collections inherited-headers auto-save | `CollectionInheritedHeadersWorkflow` | ✅ Done (2026-06-12) — debounce, suppression scopes, pending/flush, persistence; Main keeps dispatcher marshalling and the live-preview editor sync |
 | Layout tree/restore | `LayoutWorkflow`, `LayoutTreeWorkflow` | 🔶 Partial — named layouts, geometry, and persistence still in Main |
 | Options persistence | `ApplicationOptionsWorkflow`, `ApplicationOptionsSnapshot`, `OptionsPersistenceOutcome` | ✅ Done — auto-save debounce, build/validate, save/export/import; the per-option `Apply*` UI projections stay in Main by design (they mutate Avalonia/app state) |
-| Scheduled jobs add/remove | — | ❌ Not started |
+| Scheduled jobs add/remove | `ScheduledJobsWorkflow` | ✅ Done (2026-06-12) — add (interval clamped to `MinIntervalSeconds`), remove (stop + delete + dispose), load with auto-start-on-launch, and job VM disposal; Main keeps the commands and `LeftPanelTab` switch |
 | Request tabs + history | — | ❌ Not started |
 
 <a id="remaining-slices--ordered-plan-2026-06-11"></a>
@@ -123,8 +123,8 @@ Execute one slice per PR, in this order (lowest coupling first), following the W
 
 1. ~~**Options workflow**~~ ✅ Done — `ApplicationOptionsWorkflow` (`Features/Options/`) owns the debounced auto-save pipeline (injectable `IScheduler`, `TestScheduler`-tested), nesting auto-save suppression scopes, snapshot-based `BuildOptions` validation, and the save/export/import persistence flows with `OptionsPersistenceOutcome` results. Main keeps the option `[Reactive]` properties, the per-option `Apply*` UI projections (theme/font/TLS mutate Avalonia and service state), and the file pickers. Tests: `ApplicationOptionsWorkflowTests` + `ApplicationOptionsWorkflowPersistenceTests`.
 2. ~~**Collections UI workflows**~~ ✅ Done (2026-06-12) — `CollectionInheritedHeadersWorkflow` owns the inherited-headers debounced auto-save (injectable `IScheduler`, `TestScheduler`-tested), suppression scopes, pending/flush tracking, snapshot persistence, and the shared `BuildHeaders`/`MergeCollectionAndRequestHeaders`/`HeadersEqual` helpers; `CollectionFilterWorkflow` owns filter/sort/group with expansion-state preservation; import/delete moved into `CollectionsManagementCoordinator` (`ImportCollectionOutcome`/`DeleteCollectionOutcome`). Main keeps the `[Reactive]` form-visibility state (per the established convention), the dispatcher marshalling, the file picker, and the live-preview editor sync (`SyncActiveCollectionRequestInheritedHeaders` projects onto the request editor). DynamicData was considered and deliberately not adopted — the extracted pipeline stays behavior-identical; revisit if the history slice adopts it. Tests: `CollectionInheritedHeadersWorkflowTests`, `CollectionFilterWorkflowTests`, `CollectionsManagementCoordinatorTests`.
-3. **Scheduled jobs workflow** *(next)* — move `AddScheduledJob`/`RemoveScheduledJobAsync` and persistence hooks into a `ScheduledJobsWorkflow` next to `ScheduledJobService`.
-4. **Request tabs + history** — extract tab lifecycle (`NewRequestTab`, `CloseRequestTab`, `ApplyActiveRequestTab`, `SaveResponseStateForTab`) and history load/filter (`LoadHistoryAsync`, `ApplyHistoryFilter`, `LoadHistoryRequest`) into feature-scoped classes.
+3. ~~**Scheduled jobs workflow**~~ ✅ Done (2026-06-12) — `ScheduledJobsWorkflow` (`Features/ScheduledJobs/`) owns the `Jobs` collection and its lifecycle: `AddJob` (interval clamped to the moved `MinIntervalSeconds` constant), `RemoveJobAsync` (stop + repository delete + dispose), `LoadJobsAsync` (replace + optional auto-start on launch), and disposal of job view models. Main keeps the `[ReactiveCommand]` entry points, the `ScheduledJobs` pass-through property for XAML, and the `LeftPanelTab` switch. Tests: `ScheduledJobsWorkflowTests` (uses a never-advanced `TestScheduler` on `ScheduledJobService` so started jobs never tick).
+4. **Request tabs + history** *(next)* — extract tab lifecycle (`NewRequestTab`, `CloseRequestTab`, `ApplyActiveRequestTab`, `SaveResponseStateForTab`) and history load/filter (`LoadHistoryAsync`, `ApplyHistoryFilter`, `LoadHistoryRequest`) into feature-scoped classes.
 5. **Layout management** — finish the layout slice: named layout save/restore/remove, window geometry, `PersistCurrentLayout`/`ApplyLayoutSnapshot`/`ReapplyStartupLayout` on top of the existing `LayoutWorkflow`/`LayoutTreeWorkflow`. Largest and riskiest; do it once the rest of Main is thin.
 6. **Phase 3 delegation cleanup** — remove `IResponseActionsContext` pass-throughs and other temporary delegation from Main once XAML binds to feature VMs directly.
 7. **DockFactory feature registrations** — only after the slices above: replace the `MainWindowViewModel` constructor dependency in `DockFactory` with per-feature dockable registrations (step 2 in `clean-feature-separation.md`). Deliberately deferred so registrations can point at clean feature VMs.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -16,6 +16,14 @@ As of the latest build (2026-04-24, after adding Kestrel integration tests for W
 - **Arbor.HttpClient.Desktop:** 65.6% line coverage (3334/5081 lines), 51.8% branch coverage (822/1587 branches)
 - **Arbor.HttpClient.Testing:** ~13% line coverage (test infrastructure — indirect coverage is acceptable)
 
+### New code introduced in the scheduled-jobs workflow slice (2026-06-12)
+
+> Measured with `dotnet test src/Arbor.HttpClient.Desktop.E2E.Tests/... -- --filter-class "...ScheduledJobsWorkflowTests" --coverage --coverage-output-format cobertura` (Microsoft.Testing.Extensions.CodeCoverage).
+
+| Class | Line coverage | Notes |
+|---|---|---|
+| `ScheduledJobsWorkflow` | **100%** ✅ | Add (interval clamp), remove (null/persisted/unsaved), load (auto-start on/off, follow-redirects default, reload), dispose — all paths covered by `ScheduledJobsWorkflowTests` |
+
 ### New code introduced in the collections UI workflows slice (2026-06-12)
 
 > Measured with the `dotnet-coverage` CLI (`dotnet-coverage collect -f cobertura -- dotnet test src/Arbor.HttpClient.Desktop.E2E.Tests/...`) because the test projects had moved to Microsoft.Testing.Platform, which ignores the VSTest-based `coverlet.collector`. With this tool the Desktop project measured **70.4% line coverage** overall (not directly comparable to the coverlet baseline below, but no decrease). The tooling gap has since been fixed: the test projects now reference `Microsoft.Testing.Extensions.CodeCoverage`, so plain `dotnet test ... -- --coverage` works again — see [Local Coverage Workflow](#locally) and [CI Integration](#ci-integration).

--- a/src/Arbor.HttpClient.Desktop.E2E.Tests/ScheduledJobsWorkflowTests.cs
+++ b/src/Arbor.HttpClient.Desktop.E2E.Tests/ScheduledJobsWorkflowTests.cs
@@ -1,0 +1,184 @@
+using Arbor.HttpClient.Desktop.Features.ScheduledJobs;
+using Arbor.HttpClient.Testing.Fakes;
+using Arbor.HttpClient.Testing.Repositories;
+using Microsoft.Reactive.Testing;
+using Serilog.Core;
+using Arbor.HttpClient.Core.HttpRequest;
+using Arbor.HttpClient.Core.ScheduledJobs;
+
+namespace Arbor.HttpClient.Desktop.E2E.Tests;
+
+public sealed class ScheduledJobsWorkflowTests
+{
+    private sealed class Harness : IDisposable
+    {
+        private readonly System.Net.Http.HttpClient _httpClient;
+
+        public InMemoryScheduledJobRepository Repository { get; } = new();
+
+        public ScheduledJobService JobService { get; }
+
+        public ScheduledJobsWorkflow Workflow { get; }
+
+        public Harness()
+        {
+            var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok"),
+                ReasonPhrase = "OK"
+            });
+            _httpClient = new System.Net.Http.HttpClient(handler);
+            var httpRequestService = new HttpRequestService(_httpClient, new InMemoryRequestHistoryRepository());
+
+            // TestScheduler is never advanced, so started jobs register without ever ticking.
+            JobService = new ScheduledJobService(httpRequestService, Logger.None, scheduler: new TestScheduler());
+            Workflow = new ScheduledJobsWorkflow(Repository, JobService);
+        }
+
+        public Task<int> SeedJobAsync(string name, bool autoStart = false, bool? followRedirects = null) =>
+            Repository.SaveAsync(
+                new ScheduledJobConfig(
+                    Id: 0,
+                    Name: name,
+                    Method: "GET",
+                    Url: "http://localhost:5000/test",
+                    Body: null,
+                    HeadersJson: null,
+                    IntervalSeconds: 5,
+                    AutoStart: autoStart,
+                    FollowRedirects: followRedirects),
+                TestContext.Current.CancellationToken);
+
+        public void Dispose()
+        {
+            Workflow.Dispose();
+            JobService.Dispose();
+            _httpClient.Dispose();
+        }
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public void AddJob_IntervalBelowMinimum_ClampsToMinimum()
+    {
+        using var harness = new Harness();
+
+        var job = harness.Workflow.AddJob(defaultIntervalSeconds: 0, followRedirects: true);
+
+        job.IntervalSeconds.Should().Be(ScheduledJobsWorkflow.MinIntervalSeconds);
+        harness.Workflow.Jobs.Should().ContainSingle().Which.Should().BeSameAs(job);
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public void AddJob_WithDefaults_AppliesIntervalAndFollowRedirects()
+    {
+        using var harness = new Harness();
+
+        var job = harness.Workflow.AddJob(defaultIntervalSeconds: 90, followRedirects: false);
+
+        job.IntervalSeconds.Should().Be(90);
+        job.FollowRedirects.Should().BeFalse();
+        job.Id.Should().Be(0);
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task RemoveJobAsync_NullJob_LeavesJobsUnchanged()
+    {
+        using var harness = new Harness();
+        harness.Workflow.AddJob(defaultIntervalSeconds: 60, followRedirects: true);
+
+        await harness.Workflow.RemoveJobAsync(null, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().ContainSingle();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task RemoveJobAsync_PersistedJob_StopsJobAndDeletesFromRepository()
+    {
+        using var harness = new Harness();
+        var jobId = await harness.SeedJobAsync("Persisted job", autoStart: true);
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: true, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+        var job = harness.Workflow.Jobs.Single();
+
+        await harness.Workflow.RemoveJobAsync(job, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().BeEmpty();
+        harness.JobService.IsRunning(jobId).Should().BeFalse();
+        var remaining = await harness.Repository.GetAllAsync(TestContext.Current.CancellationToken);
+        remaining.Should().BeEmpty();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task RemoveJobAsync_UnsavedJob_RemovesWithoutTouchingRepository()
+    {
+        using var harness = new Harness();
+        await harness.SeedJobAsync("Persisted job");
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: false, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+        var unsavedJob = harness.Workflow.AddJob(defaultIntervalSeconds: 60, followRedirects: true);
+
+        await harness.Workflow.RemoveJobAsync(unsavedJob, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().ContainSingle().Which.Id.Should().NotBe(0);
+        var remaining = await harness.Repository.GetAllAsync(TestContext.Current.CancellationToken);
+        remaining.Should().ContainSingle();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task LoadJobsAsync_AutoStartEnabled_StartsAutoStartJobs()
+    {
+        using var harness = new Harness();
+        var autoStartJobId = await harness.SeedJobAsync("Auto start", autoStart: true);
+        await harness.SeedJobAsync("Manual start", autoStart: false);
+
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: true, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().HaveCount(2);
+        harness.Workflow.Jobs.Single(job => job.Id == autoStartJobId).IsRunning.Should().BeTrue();
+        harness.Workflow.Jobs.Single(job => job.Id != autoStartJobId).IsRunning.Should().BeFalse();
+        harness.JobService.IsRunning(autoStartJobId).Should().BeTrue();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task LoadJobsAsync_AutoStartOnLaunchDisabled_LoadsJobsWithoutStarting()
+    {
+        using var harness = new Harness();
+        var jobId = await harness.SeedJobAsync("Auto start", autoStart: true);
+
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: false, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+
+        var job = harness.Workflow.Jobs.Should().ContainSingle().Subject;
+        job.AutoStart.Should().BeTrue();
+        job.IsRunning.Should().BeFalse();
+        harness.JobService.IsRunning(jobId).Should().BeFalse();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task LoadJobsAsync_ConfigWithoutFollowRedirects_UsesDefault()
+    {
+        using var harness = new Harness();
+        await harness.SeedJobAsync("No redirect preference", followRedirects: null);
+
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: false, defaultFollowRedirects: false, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().ContainSingle().Which.FollowRedirects.Should().BeFalse();
+    }
+
+    [AvaloniaFact(Timeout = 10_000)]
+    public async Task LoadJobsAsync_CalledTwice_ReplacesExistingJobs()
+    {
+        using var harness = new Harness();
+        await harness.SeedJobAsync("Persisted job");
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: false, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+        var firstLoadJob = harness.Workflow.Jobs.Single();
+
+        await harness.Workflow.LoadJobsAsync(
+            autoStartOnLaunch: false, defaultFollowRedirects: true, TestContext.Current.CancellationToken);
+
+        harness.Workflow.Jobs.Should().ContainSingle().Which.Should().NotBeSameAs(firstLoadJob);
+    }
+}

--- a/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/Main/MainWindowViewModel.cs
@@ -73,10 +73,10 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     private readonly HttpResponseProjectionWorkflow _httpResponseProjectionWorkflow = new();
     private readonly IRequestHistoryRepository _requestHistoryRepository;
     private readonly ICollectionRepository _collectionRepository;
-    private readonly IScheduledJobRepository _scheduledJobRepository;
     private CollectionsWorkflow _collectionsWorkflow = null!;
     private CollectionsManagementCoordinator _collectionsManagementCoordinator = null!;
     private readonly ScheduledJobService _scheduledJobService;
+    private readonly ScheduledJobsWorkflow _scheduledJobsWorkflow;
     private readonly LogWindowViewModel _logWindowViewModel;
     private readonly VariableResolver _variableResolver;
     private readonly ApplicationOptionsStore? _applicationOptionsStore;
@@ -313,7 +313,6 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     public const string SystemThemeOption = "System";
     public const string DarkThemeOption = "Dark";
     public const string LightThemeOption = "Light";
-    public const int MinScheduledJobIntervalSeconds = 1;
 
     public IReadOnlyList<string> ThemeOptions { get; } =
     [
@@ -671,8 +670,8 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         _httpRequestService = httpRequestService;
         _requestHistoryRepository = requestHistoryRepository;
         _collectionRepository = collectionRepository;
-        _scheduledJobRepository = scheduledJobRepository;
         _scheduledJobService = scheduledJobService;
+        _scheduledJobsWorkflow = new ScheduledJobsWorkflow(scheduledJobRepository, scheduledJobService);
         _logWindowViewModel = logWindowViewModel;
         _variableResolver = new VariableResolver();
         _applicationOptionsStore = applicationOptionsStore;
@@ -948,7 +947,6 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         CollectionInheritedHeaders = [];
         FilteredCollectionItems = [];
         CollectionGroups = [];
-        ScheduledJobs = [];
         SavedLayoutNames = [];
 
         // Cancellation: ExecutePrimaryAction cancels _sendRequestCts, which is linked to the
@@ -1105,7 +1103,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     public ObservableCollection<CollectionGroupViewModel> CollectionGroups { get; }
     public ObservableCollection<RequestEnvironment> Environments => _environmentsViewModel.Environments;
     public ObservableCollection<EnvironmentVariableViewModel> ActiveEnvironmentVariables => _environmentsViewModel.ActiveEnvironmentVariables;
-    public ObservableCollection<ScheduledJobViewModel> ScheduledJobs { get; }
+    public ObservableCollection<ScheduledJobViewModel> ScheduledJobs => _scheduledJobsWorkflow.Jobs;
     public ObservableCollection<string> SavedLayoutNames { get; }
     public LogWindowViewModel LogWindowViewModel => _logWindowViewModel;
     public RequestEditorViewModel RequestEditor => _requestEditor;
@@ -1378,32 +1376,13 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     [ReactiveCommand]
     private void AddScheduledJob()
     {
-        var vm = new ScheduledJobViewModel(_scheduledJobRepository, _scheduledJobService)
-        {
-            IntervalSeconds = Math.Max(MinScheduledJobIntervalSeconds, DefaultScheduledJobIntervalSeconds),
-            FollowRedirects = FollowHttpRedirects
-        };
-        ScheduledJobs.Add(vm);
+        _scheduledJobsWorkflow.AddJob(DefaultScheduledJobIntervalSeconds, FollowHttpRedirects);
         LeftPanelTab = "ScheduledJobs";
     }
 
     [ReactiveCommand]
-    private async Task RemoveScheduledJobAsync(ScheduledJobViewModel? job)
-    {
-        if (job is null)
-        {
-            return;
-        }
-
-        _scheduledJobService.Stop(job.Id);
-        if (job.Id != 0)
-        {
-            await _scheduledJobRepository.DeleteAsync(job.Id);
-        }
-
-        ScheduledJobs.Remove(job);
-        job.Dispose();
-    }
+    private Task RemoveScheduledJobAsync(ScheduledJobViewModel? job) =>
+        _scheduledJobsWorkflow.RemoveJobAsync(job);
 
     [ReactiveCommand]
     private void ShowHistoryTab()
@@ -2294,10 +2273,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
         _draftAutoSaveCts?.Dispose();
         _draftPersistenceService?.ClearDraft();
         _scheduledJobService.Dispose();
-        foreach (var scheduledJobViewModel in ScheduledJobs)
-        {
-            scheduledJobViewModel.Dispose();
-        }
+        _scheduledJobsWorkflow.Dispose();
         _fileWatcherCts?.Cancel();
         _fileWatcherCts?.Dispose();
         _requestBodyWatcher?.Dispose();
@@ -2483,7 +2459,7 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
             LoadHistoryAsync(cancellationToken),
             LoadCollectionsAsync(cancellationToken),
             _environmentsViewModel.LoadEnvironmentsAsync(cancellationToken),
-            LoadScheduledJobsAsync(cancellationToken)).ConfigureAwait(false);
+            _scheduledJobsWorkflow.LoadJobsAsync(AutoStartScheduledJobsOnLaunch, FollowHttpRedirects, cancellationToken)).ConfigureAwait(false);
 
         var demoSeedResult = await SeedDemoDataAsync(cancellationToken).ConfigureAwait(false);
         if (demoSeedResult.SeededCollectionId is { } newCollectionId)
@@ -3025,30 +3001,6 @@ public partial class MainWindowViewModel : ReactiveViewModelBase, IResponseActio
     }
 
     private void QueueOptionsAutoSave() => _optionsWorkflow.QueueAutoSave();
-
-
-    private async Task LoadScheduledJobsAsync(CancellationToken cancellationToken = default)
-    {
-        var all = await _scheduledJobRepository.GetAllAsync(cancellationToken);
-
-        foreach (var scheduledJobViewModel in ScheduledJobs)
-        {
-            scheduledJobViewModel.Dispose();
-        }
-
-        ScheduledJobs.Clear();
-        foreach (var config in all)
-        {
-            var vm = ScheduledJobViewModel.FromConfig(config, _scheduledJobRepository, _scheduledJobService, FollowHttpRedirects);
-            ScheduledJobs.Add(vm);
-
-            if (AutoStartScheduledJobsOnLaunch && config.AutoStart && !_scheduledJobService.IsRunning(config.Id))
-            {
-                _scheduledJobService.Start(config, vm.IsWebViewEnabled ? vm.HandleResponseAsync : null);
-                vm.IsRunning = true;
-            }
-        }
-    }
 
     private IReadOnlyList<EnvironmentVariable> GetActiveVariablesForEditor() =>
         _environmentsViewModel.GetActiveVariablesForEditor();

--- a/src/Arbor.HttpClient.Desktop/Features/ScheduledJobs/ScheduledJobViewModel.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/ScheduledJobs/ScheduledJobViewModel.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using Arbor.HttpClient.Desktop.Features.Main;
 using Arbor.HttpClient.Desktop.Features.ScheduledJobs;
 using Arbor.HttpClient.Desktop.Features.WebView;
 using Arbor.HttpClient.Desktop.Shared;
@@ -165,7 +164,7 @@ public sealed partial class ScheduledJobViewModel : ReactiveViewModelBase
         new(Id, Name, Method, Url,
             string.IsNullOrWhiteSpace(Body) ? null : Body,
             null, // headers not yet supported in the scheduled-job editor
-            Math.Max(MainWindowViewModel.MinScheduledJobIntervalSeconds, IntervalSeconds),
+            Math.Max(ScheduledJobsWorkflow.MinIntervalSeconds, IntervalSeconds),
             AutoStart,
             FollowRedirects,
             UseWebView: UseWebView);

--- a/src/Arbor.HttpClient.Desktop/Features/ScheduledJobs/ScheduledJobsWorkflow.cs
+++ b/src/Arbor.HttpClient.Desktop/Features/ScheduledJobs/ScheduledJobsWorkflow.cs
@@ -1,0 +1,104 @@
+using System.Collections.ObjectModel;
+using Arbor.HttpClient.Core.ScheduledJobs;
+
+namespace Arbor.HttpClient.Desktop.Features.ScheduledJobs;
+
+/// <summary>
+/// Owns the scheduled-job list lifecycle: creating new job view models, removing jobs
+/// (stop, delete from the repository, dispose), and loading persisted jobs with
+/// optional auto-start on launch.
+/// </summary>
+public sealed class ScheduledJobsWorkflow : IDisposable
+{
+    public const int MinIntervalSeconds = 1;
+
+    private readonly IScheduledJobRepository _scheduledJobRepository;
+    private readonly ScheduledJobService _scheduledJobService;
+
+    public ScheduledJobsWorkflow(
+        IScheduledJobRepository scheduledJobRepository,
+        ScheduledJobService scheduledJobService)
+    {
+        _scheduledJobRepository = scheduledJobRepository;
+        _scheduledJobService = scheduledJobService;
+    }
+
+    /// <summary>Job view models bound by the scheduled-jobs panel.</summary>
+    public ObservableCollection<ScheduledJobViewModel> Jobs { get; } = [];
+
+    /// <summary>
+    /// Creates a new unsaved job with the given defaults and adds it to <see cref="Jobs"/>.
+    /// The interval is clamped to <see cref="MinIntervalSeconds"/>.
+    /// </summary>
+    public ScheduledJobViewModel AddJob(int defaultIntervalSeconds, bool followRedirects)
+    {
+        var scheduledJobViewModel = new ScheduledJobViewModel(_scheduledJobRepository, _scheduledJobService)
+        {
+            IntervalSeconds = Math.Max(MinIntervalSeconds, defaultIntervalSeconds),
+            FollowRedirects = followRedirects
+        };
+        Jobs.Add(scheduledJobViewModel);
+        return scheduledJobViewModel;
+    }
+
+    /// <summary>
+    /// Stops the job, deletes it from the repository when it has been persisted,
+    /// removes it from <see cref="Jobs"/>, and disposes the view model.
+    /// </summary>
+    public async Task RemoveJobAsync(ScheduledJobViewModel? job, CancellationToken cancellationToken = default)
+    {
+        if (job is null)
+        {
+            return;
+        }
+
+        _scheduledJobService.Stop(job.Id);
+        if (job.Id != 0)
+        {
+            await _scheduledJobRepository.DeleteAsync(job.Id, cancellationToken);
+        }
+
+        Jobs.Remove(job);
+        job.Dispose();
+    }
+
+    /// <summary>
+    /// Replaces <see cref="Jobs"/> with the persisted configurations, starting jobs marked
+    /// for auto-start when <paramref name="autoStartOnLaunch"/> is enabled.
+    /// </summary>
+    public async Task LoadJobsAsync(
+        bool autoStartOnLaunch,
+        bool defaultFollowRedirects,
+        CancellationToken cancellationToken = default)
+    {
+        var configs = await _scheduledJobRepository.GetAllAsync(cancellationToken);
+
+        foreach (var scheduledJobViewModel in Jobs)
+        {
+            scheduledJobViewModel.Dispose();
+        }
+
+        Jobs.Clear();
+        foreach (var config in configs)
+        {
+            var scheduledJobViewModel = ScheduledJobViewModel.FromConfig(
+                config, _scheduledJobRepository, _scheduledJobService, defaultFollowRedirects);
+            Jobs.Add(scheduledJobViewModel);
+
+            if (autoStartOnLaunch && config.AutoStart && !_scheduledJobService.IsRunning(config.Id))
+            {
+                _scheduledJobService.Start(config, scheduledJobViewModel.IsWebViewEnabled ? scheduledJobViewModel.HandleResponseAsync : null);
+                scheduledJobViewModel.IsRunning = true;
+            }
+        }
+    }
+
+    /// <summary>Disposes the job view models. The job service is owned and disposed by the host.</summary>
+    public void Dispose()
+    {
+        foreach (var scheduledJobViewModel in Jobs)
+        {
+            scheduledJobViewModel.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Continues the MainWindowViewModel split plan (slice 3: scheduled jobs).

- New ScheduledJobsWorkflow (Features/ScheduledJobs/) owns the Jobs
  collection and its lifecycle: AddJob (interval clamped to
  MinIntervalSeconds), RemoveJobAsync (stop + repository delete +
  dispose), LoadJobsAsync (replace + optional auto-start on launch),
  and disposal of job view models.
- MainWindowViewModel keeps the [ReactiveCommand] entry points, the
  ScheduledJobs pass-through property for XAML, and the LeftPanelTab
  switch; MinScheduledJobIntervalSeconds moved to the workflow.
- 9 focused tests in ScheduledJobsWorkflowTests (100% line coverage of
  the new class, measured with Microsoft.Testing.Extensions.CodeCoverage);
  a never-advanced TestScheduler keeps started jobs from ticking.
- Docs updated: split plan slice status, feature-separation overview,
  coverage notes.

https://claude.ai/code/session_01HxtyKdkQUjZNCAueXA7YLw